### PR TITLE
Add additional infrastructure for R later package

### DIFF
--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -617,6 +617,17 @@ describe('Evaluate objects without shelters', () => {
   });
 });
 
+test('Invoke a wasm function from the main thread', async () => {
+  const fn = (await webR.evalR(`
+    webr::eval_js("
+      Module.addFunction((x) => x + 1, 'ii')
+    ")
+  `)) as RDouble;
+  const ptr = await fn.toNumber();
+  const ret = await webR.invokeWasmFunction(ptr, 667430);
+  expect(ret).toEqual(667431);
+});
+
 beforeEach(() => {
   jest.restoreAllMocks();
 });

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -618,31 +618,28 @@ describe('Evaluate objects without shelters', () => {
 });
 
 test('Invoke a wasm function from the main thread', async () => {
-  const fn = (await webR.evalR(`
+  const ptr = (await webR.evalRNumber(`
     webr::eval_js("
-      Module.addFunction((x) => x + 1, 'ii')
+      Module.addFunction((x, y) => x + y, 'iii')
     ")
-  `)) as RDouble;
-  const ptr = await fn.toNumber();
-  const ret = await webR.invokeWasmFunction(ptr, 667430);
-  expect(ret).toEqual(667431);
+  `));
+  const ret = await webR.invokeWasmFunction(ptr, 667430, 5);
+  expect(ret).toEqual(667435);
 });
 
 test('Invoke a wasm function after a delay', async () => {
-  const fn = (await webR.evalR(`
+  const ptr = (await webR.evalRNumber(`
     webr::eval_js("
       Module.addFunction(() => {
         const str = Module.allocateUTF8('Hello, World!\\\\n');
         Module._printf(str);
         Module._free(str);
-        return 0;
-      }, 'ii')
+      }, 'vi')
     ")
-  `)) as RDouble;
-  const ptr = await fn.toNumber();
+  `));
   await webR.flush();
   await webR.evalR(`
-    webr::eval_js("Module.webr.setTimeoutWasm(${ptr}, 0, 500)")
+    webr::eval_js("Module.webr.setTimeoutWasm(${ptr}, 500)")
   `);
   expect((await webR.read()).data).toBe('Hello, World!');
 });

--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -164,6 +164,10 @@ export class ServiceWorkerChannelMain extends ChannelMain {
         this.resolveResponse(message as Response);
         return;
 
+      case 'system':
+        this.systemQueue.put(message.data as Message);
+        return;
+
       default:
         this.outputQueue.put(message);
         return;
@@ -210,6 +214,10 @@ export class ServiceWorkerChannelWorker implements ChannelWorker {
 
   write(msg: Message, transfer?: [Transferable]) {
     this.#ep.postMessage(msg, transfer);
+  }
+
+  writeSystem(msg: Message, transfer?: [Transferable]) {
+    this.#ep.postMessage({ type: 'system', data: msg }, transfer);
   }
 
   syncRequest(message: Message): Response {

--- a/src/webR/chan/channel-shared.ts
+++ b/src/webR/chan/channel-shared.ts
@@ -78,6 +78,10 @@ export class SharedBufferChannelMain extends ChannelMain {
         this.resolveResponse(message as Response);
         return;
 
+      case 'system':
+        this.systemQueue.put(message.data as Message);
+        return;
+
       default:
         this.outputQueue.put(message);
         return;
@@ -129,6 +133,10 @@ export class SharedBufferChannelWorker implements ChannelWorker {
 
   write(msg: Message, transfer?: [Transferable]) {
     this.#ep.postMessage(msg, transfer);
+  }
+
+  writeSystem(msg: Message, transfer?: [Transferable]) {
+    this.#ep.postMessage({ type: 'system', data: msg }, transfer);
   }
 
   read(): Message {

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -31,6 +31,7 @@ import { WebRPayload, WebRPayloadWorker, webRPayloadError } from '../payload';
 export abstract class ChannelMain {
   inputQueue = new AsyncQueue<Message>();
   outputQueue = new AsyncQueue<Message>();
+  systemQueue = new AsyncQueue<Message>();
 
   #parked = new Map<string, { resolve: ResolveFn; reject: RejectFn }>();
 
@@ -48,6 +49,10 @@ export abstract class ChannelMain {
       msg.push(await this.read());
     }
     return msg;
+  }
+
+  async readSystem(): Promise<Message> {
+    return await this.systemQueue.get();
   }
 
   write(msg: Message): void {
@@ -86,6 +91,7 @@ export abstract class ChannelMain {
 export interface ChannelWorker {
   resolve(): void;
   write(msg: Message, transfer?: [Transferable]): void;
+  writeSystem(msg: Message, transfer?: [Transferable]): void;
   read(): Message;
   handleInterrupt(): void;
   setInterrupt(interrupt: () => void): void;

--- a/src/webR/emscripten.ts
+++ b/src/webR/emscripten.ts
@@ -117,6 +117,7 @@ export interface Module extends EmscriptenModule {
     resolveInit: () => void;
     handleEvents: () => void;
     evalJs: (code: RPtr) => number;
+    setTimeoutWasm: (ptr: EmPtr, data: EmPtr, delay: number) => void;
   };
 }
 

--- a/src/webR/emscripten.ts
+++ b/src/webR/emscripten.ts
@@ -33,6 +33,7 @@ export interface Module extends EmscriptenModule {
   setValue: typeof setValue;
   UTF8ToString: typeof UTF8ToString;
   callMain: (args: string[]) => void;
+  getWasmTableEntry: (entry: number) => Function;
   // R symbols from Rinternals.h
   _ATTRIB: (ptr: RPtr) => RPtr;
   _CAR: (ptr: RPtr) => RPtr;
@@ -121,7 +122,7 @@ export interface Module extends EmscriptenModule {
 
 export const Module = {} as Module;
 
-type EmPtr = ReturnType<typeof Module.allocateUTF8>;
+export type EmPtr = ReturnType<typeof Module.allocateUTF8>;
 
 export interface DictEmPtrs {
   [key: string]: EmPtr;

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -3,6 +3,7 @@
  */
 import { Message } from './chan/message';
 import { UUID as ShelterID } from './chan/task-common';
+import { EmPtr } from './emscripten';
 import { WebRPayloadWorker, WebRPayloadPtr } from './payload';
 import { RType, WebRData } from './robj';
 
@@ -118,6 +119,12 @@ export interface FSWriteFileMessage extends Message {
     data: ArrayBufferView;
     flags?: string;
   };
+}
+
+/** @internal */
+export interface InvokeWasmFunctionMessage extends Message {
+  type: 'invokeWasmFunction';
+  data: { ptr: EmPtr; data: EmPtr };
 }
 
 /** @internal */

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -124,7 +124,7 @@ export interface FSWriteFileMessage extends Message {
 /** @internal */
 export interface InvokeWasmFunctionMessage extends Message {
   type: 'invokeWasmFunction';
-  data: { ptr: EmPtr; data: EmPtr };
+  data: { ptr: EmPtr; args: number[] };
 }
 
 /** @internal */

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -258,12 +258,12 @@ export class WebR {
      */
     while (msg.type === 'setTimeoutWasm') {
       setTimeout(
-        (ptr: EmPtr, data: EmPtr) => {
-          this.invokeWasmFunction(ptr, data);
+        (ptr: EmPtr, args: number[]) => {
+          this.invokeWasmFunction(ptr, ...args);
         },
         msg.data.delay as number,
         msg.data.ptr,
-        msg.data.data
+        msg.data.args
       );
       msg = await this.#chan.read();
     }
@@ -381,10 +381,10 @@ export class WebR {
     }
   }
 
-  async invokeWasmFunction(ptr: EmPtr, data: EmPtr): Promise<EmPtr> {
+  async invokeWasmFunction(ptr: EmPtr, ...args: number[]): Promise<EmPtr> {
     const msg = {
       type: 'invokeWasmFunction',
-      data: { ptr, data },
+      data: { ptr, args },
     } as InvokeWasmFunctionMessage;
     const resp = await this.#chan.request(msg);
     return resp.obj as EmPtr;

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -360,6 +360,15 @@ export class WebR {
     }
   }
 
+  async invokeWasmFunction(ptr: EmPtr, data: EmPtr): Promise<EmPtr> {
+    const msg = {
+      type: 'invokeWasmFunction',
+      data: { ptr, data },
+    } as InvokeWasmFunctionMessage;
+    const resp = await this.#chan.request(msg);
+    return resp.obj as EmPtr;
+  }
+
   FS = {
     lookupPath: async (path: string): Promise<FSNode> => {
       const msg: FSMessage = { type: 'lookupPath', data: { path } };

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -705,6 +705,10 @@ function init(config: Required<WebROptions>) {
       throwUnreachable();
       return 0;
     },
+
+    setTimeoutWasm: (ptr: EmPtr, data: EmPtr, delay: number): void => {
+      chan?.write({ type: 'setTimeoutWasm', data: { ptr, data, delay } });
+    },
   };
 
   Module.locateFile = (path: string) => _config.baseUrl + path;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -706,7 +706,7 @@ function init(config: Required<WebROptions>) {
     },
 
     setTimeoutWasm: (ptr: EmPtr, delay: number, ...args: number[]): void => {
-      chan?.write({ type: 'setTimeoutWasm', data: { ptr, delay, args } });
+      chan?.writeSystem({ type: 'setTimeoutWasm', data: { ptr, delay, args } });
     },
   };
 

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -379,8 +379,7 @@ function dispatch(msg: Message): void {
 
           case 'invokeWasmFunction': {
             const msg = reqMsg as InvokeWasmFunctionMessage;
-            // Wasm function has expected signature `ii`
-            const res = Module.getWasmTableEntry(msg.data.ptr)(msg.data.data) as number;
+            const res = Module.getWasmTableEntry(msg.data.ptr)(...msg.data.args) as number;
             write({
               payloadType: 'raw',
               obj: res,
@@ -706,8 +705,8 @@ function init(config: Required<WebROptions>) {
       return 0;
     },
 
-    setTimeoutWasm: (ptr: EmPtr, data: EmPtr, delay: number): void => {
-      chan?.write({ type: 'setTimeoutWasm', data: { ptr, data, delay } });
+    setTimeoutWasm: (ptr: EmPtr, delay: number, ...args: number[]): void => {
+      chan?.write({ type: 'setTimeoutWasm', data: { ptr, delay, args } });
     },
   };
 


### PR DESCRIPTION
We would like to be able to use the later R package as a prerequisite for webR compatibility with shiny, but for this to work the later package needs some support from webR. There are a few ways to implement later's delay mechanism in the context of a webR package,

1) JavaScript's `async/await` mechanism would probably work well, but until the [stack switching Wasm proposal](https://github.com/WebAssembly/stack-switching) is accepted and has been implemented in browsers, we are currently stuck blocking in the worker thread, unable to yield to the event loop.

2) We could spawn a new web worker, delay for some time in the new web worker, then signal back to the R worker thread that the delay time has passed. This would require careful expansion of the channel mechanism to co-ordinate messages between transient web workers and the R worker thread.

3) The later package currently implements a delay on POSIX platforms using pthreads. However, Emscripten pthreads are marked as experimental when used in combination with `SIDE_MODULE`s, and previous experiments with using the `-pthreads` flag when building R packages for wasm have not been successful.

So, as a first step, this PR implements a simpler form of solution 2). Rather than spinning up a new web worker and adding new code to co-ordinate messaging, the delay is instead just scheduled on the main thread using JSs `setTimeout()` function, and a message is sent back to the worker thread after the delay using the current channel mechanism.

* A Wasm function pointer can be invoked from the main thread using a new request type of `invokeWasmFunction`. The function can be invoked with an arbitrary number of arguments of type `number` and optionally return a `number`. Since pointers are just `number` this also allows for functions like `void* fn(void* data)`.

* The worker thread may output a new message of type `setTimeoutWasm`. The main thread has been set up to listen for this type of message. Rather than forwarding the message out to the application, the main thread will execute a `setTimeout` so that after a given delay an `invokeWasmFunction` request is then sent to the worker thread for execution.

See https://github.com/r-lib/later/commit/3e3f10f2f1bc69b9232fafe9a95a257a8f350b5a for an example of how a patched later package can be implemented using this new infrastructure.
