### PR TITLE
Set version to 0.1.0 and release

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@r-wasm/webr",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0",
   "description": "The statistical programming langauge R compiled into WASM for use in a web browser and node.",
   "keywords": [
     "webR",


### PR DESCRIPTION
When we are ready to release, we set v0.1.0 in the `package.json` for the npm package. We rebase and merge this PR and then the resulting commit should be tagged as "v0.1.0" and pushed. CI should then take care of the rest 🤞

The `package/webr/DESCRIPTION` has version 0.1.0 set already, as does the `src/docs/_quarto.yml` file. In future version bumps these files should also be changed.