### PR TITLE
Improve compatibility when running under node

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,6 @@ ROOT = $(abspath .)
 PKG_DIST = $(ROOT)/dist
 
 HTML_TEMPLATES = console.html repl.html
-ENTRY_POINTS = console/console.ts repl/repl.ts webR/webr-worker.ts
 HTML_INDEX = repl.html
 
 TS_SOURCES = $(shell find $(ROOT) \
@@ -24,7 +23,7 @@ $(DIST): $(TS_SOURCES) $(HTML_DIST) \
   Makefile webR/config.ts node_modules esbuild.js
 	cp $(DIST)/$(HTML_INDEX) $(DIST)/index.html
 	npm run build
-	rm -rf "$(DIST)/tests"
+	rm -rf "$(PKG_DIST)"
 	touch $@
 
 $(DIST)/%.html: templates/%.html
@@ -67,9 +66,8 @@ publish: $(PKG_DIST)
 
 $(PKG_DIST): Makefile webR/config.ts node_modules esbuild.js
 	npm run build
-# Cleanup npm package files for distribution
-	cp -r "$(DIST)/." "$(PKG_DIST)"
-	rm -rf "$(PKG_DIST)"/*.html "$(PKG_DIST)"/tests
+# Copy R binaries into npm package for distribution
+	cd "$(DIST)" && cp R.bin.* *.so "$(PKG_DIST)"
 	touch $@
 
 clean:

--- a/src/Makefile
+++ b/src/Makefile
@@ -69,8 +69,7 @@ $(PKG_DIST): Makefile webR/config.ts node_modules esbuild.js
 	npm run build
 # Cleanup npm package files for distribution
 	cp -r "$(DIST)/." "$(PKG_DIST)"
-	rm -rf "$(PKG_DIST)"/*.wasm "$(PKG_DIST)"/R.bin.* "$(PKG_DIST)"/*.so \
-	  "$(PKG_DIST)"/*.html "$(PKG_DIST)"/tests
+	rm -rf "$(PKG_DIST)"/*.html "$(PKG_DIST)"/tests
 	touch $@
 
 clean:

--- a/src/docs/downloading.qmd
+++ b/src/docs/downloading.qmd
@@ -23,7 +23,9 @@ const webR = new WebR();
 await webR.init();
 ```
 
-By default, webR will download the WebAssembly R binaries from CDN at start-up. If required, this behaviour can be overridden by self-hosting the contents of a [webR release package](#download-release) (or [building from source](#build-from-source)) and providing an alternative base URL for the [`WebROptions.WEBR_URL`](api/js/interfaces/WebR.WebROptions.md#webr_url) configuration setting.
+The default location from which webR will load the WebAssembly R binaries depends on the execution environment. When running in a browser, webR will download binaries from CDN at start-up. If webR is running under Node.js, it will load binaries from the local module installation directory.
+
+If required, this behaviour can be overridden by self-hosting the contents of a [webR release package](#download-release) (or [building from source](#build-from-source)) and providing an alternative base URL for the [`WebROptions.WEBR_URL`](api/js/interfaces/WebR.WebROptions.md#webr_url) configuration setting.
 
 ## Download from CDN
 

--- a/src/esbuild.js
+++ b/src/esbuild.js
@@ -8,7 +8,7 @@ function build({ input, output, platform, minify }) {
     target: ['es2020','node12'],
     minify: minify,
     sourcemap: true,
-    outfile: `../dist/${output}`,
+    outfile: output,
     logLevel: 'info',
     platform: platform,
     mainFields: ['main', 'module'],
@@ -27,41 +27,62 @@ function build({ input, output, platform, minify }) {
   }).catch(() => process.exit(1));
 }
 
-[
-  {
-    input: "webR/webr-worker.ts",
-    output: "webr-worker.js",
-    platform: 'node',
-    minify: false,
-  },
-  {
-    input: "webR/chan/serviceworker.ts",
-    output: "webr-serviceworker.js",
-    platform: 'node',
-    minify: false,
-  },
-  {
-    input: "webR/webr-main.ts",
-    output: "webr.mjs",
-    platform: 'neutral',
-    minify: false,
-  },
-  {
-    input: "webR/webr-main.ts",
-    output: "webr.node.js",
-    platform: 'node',
-    minify: false,
-  },
-  {
-    input: "repl/repl.ts",
-    output: "repl.mjs",
-    platform: 'neutral',
-    minify: true,
-  },
-  {
+const outputs = {
+  'console.mjs': {
     input: "console/console.ts",
-    output: "console.mjs",
     platform: 'neutral',
     minify: true,
   },
-].map(build);
+  'repl.mjs': {
+    input: "repl/repl.ts",
+    platform: 'neutral',
+    minify: true,
+  },
+  'webr-worker.js': {
+    input: "webR/webr-worker.ts",
+    platform: 'node',
+    minify: false,
+  },
+  'webr-serviceworker.js': {
+    input: "webR/chan/serviceworker.ts",
+    platform: 'browser',
+    minify: false,
+  },
+  'webr-serviceworker.mjs': {
+    input: "webR/chan/serviceworker.ts",
+    platform: 'neutral',
+    minify: false,
+  },
+  'webr.mjs': {
+    input: "webR/webr-main.ts",
+    platform: 'neutral',
+    minify: true,
+  },
+  'webr.cjs': {
+    input: "webR/webr-main.ts",
+    platform: 'node',
+    minify: true,
+  },
+};
+
+// Build for web release package
+[
+  'console.mjs',
+  'repl.mjs',
+  'webr-serviceworker.js',
+  'webr-worker.js',
+  'webr.mjs'
+].map( (outfile) => {
+  build(Object.assign(outputs[outfile], { output: `../dist/${outfile}`}))
+});
+
+// Build for npm release package
+[
+  'webr-serviceworker.mjs',
+  'webr-serviceworker.js',
+  'webr-worker.js',
+  'webr.cjs',
+  'webr.mjs'
+].map( (outfile) => {
+  build(Object.assign(outputs[outfile], { output: `./dist/${outfile}`}))
+});

--- a/src/esbuild.js
+++ b/src/esbuild.js
@@ -47,6 +47,12 @@ function build({ input, output, platform, minify }) {
     minify: false,
   },
   {
+    input: "webR/webr-main.ts",
+    output: "webr.node.js",
+    platform: 'node',
+    minify: false,
+  },
+  {
     input: "repl/repl.ts",
     output: "repl.mjs",
     platform: 'neutral',

--- a/src/package.json
+++ b/src/package.json
@@ -42,7 +42,7 @@
   "types": "webr-main.d.ts",
   "exports": {
     ".": {
-      "node": "./dist/webr.node.js",
+      "node": "./dist/webr.cjs",
       "default": "./dist/webr.mjs"
     },
     "./console": "./dist/console.mjs",

--- a/src/package.json
+++ b/src/package.json
@@ -41,7 +41,10 @@
   "main": "dist/webr.mjs",
   "types": "webr-main.d.ts",
   "exports": {
-    ".": "./dist/webr.mjs",
+    ".": {
+      "node": "./dist/webr.node.js",
+      "default": "./dist/webr.mjs"
+    },
     "./console": "./dist/console.mjs",
     "./repl": "./dist/repl.mjs"
   },

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "../dist",
+    "outDir": "./dist",
     "target": "ES2017",
     "module": "ES2020",
     "moduleResolution": "node",

--- a/src/webR/compat.ts
+++ b/src/webR/compat.ts
@@ -7,8 +7,7 @@ declare let process: Process;
 export const IN_NODE =
   typeof process !== 'undefined' &&
   process.release &&
-  process.release.name === 'node' &&
-  typeof process.browser === 'undefined';
+  process.release.name === 'node';
 
 // Adapted from https://github.com/pyodide/pyodide/blob/main/src/js/compat.ts
 export let loadScript: (url: string) => Promise<void>;

--- a/src/webR/config.ts.in
+++ b/src/webR/config.ts.in
@@ -1,2 +1,4 @@
-export const BASE_URL = '@@BASE_URL@@';
+import { IN_NODE } from './compat';
+
+export const BASE_URL = IN_NODE ? __dirname + '/' : '@@BASE_URL@@';
 export const PKG_BASE_URL = '@@PKG_BASE_URL@@';


### PR DESCRIPTION
This PR changes the esbuild configuration to build some outputs specifically for use with node, to be included with the webR npm package. The separate entry points for node and the browser are then managed in `package.json`.

This avoids an issue when using the default esm module output directly in node without any TS loaders (#167). I tried a fix suggested by the esbuild community, but the fix breaks webR when loaded in the browser. For now, it will likely be easier to maintain separate entry points as they are generated by the same source in any case.

In addition, two tweaks are made to improve running under node:

* Build scripts are tweaked to include webR binaries in the npm package. When running under node default to loading the webR binaries from the `node_modules` directory that already exists on disk.

* Tweak the `IN_NODE` test to correctly recognise when running in a Next.js [React Server Component](https://nextjs.org/docs/advanced-features/react-18/server-components), for #171.