### PR TITLE
Export service worker functions for use as part of existing service worker scripts.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -45,6 +45,7 @@
       "node": "./dist/webr.cjs",
       "default": "./dist/webr.mjs"
     },
+    "./chan/serviceworker": "./dist/webr-serviceworker.mjs",
     "./console": "./dist/console.mjs",
     "./repl": "./dist/repl.mjs"
   },

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -93,3 +93,13 @@ export interface ChannelWorker {
   inputOrDispatch: () => number;
   setDispatchHandler: (dispatch: (msg: Message) => void) => void;
 }
+
+/**
+ * Handler functions dealing with setup and commmunication over a Service Worker.
+ */
+export interface ServiceWorkerHandlers {
+  handleActivate: (this: ServiceWorkerGlobalScope, ev: ExtendableEvent) => any;
+  handleFetch: (this: ServiceWorkerGlobalScope, ev: FetchEvent) => any;
+  handleInstall: (this: ServiceWorkerGlobalScope, ev: ExtendableEvent) => any;
+  handleMessage: (this: ServiceWorkerGlobalScope, ev: ExtendableMessageEvent) => any;
+}


### PR DESCRIPTION
Includes #172.

Service worker functions are exported, and `handleFetch` and `handleMessage` are tweaked to return `false` if the events are not related to webR.

With this change, users with pre-existing service worker scripts can import the functions and use them as part of a bigger script. The resulting source could look something like this,

``` javascript
import { webRHandlers } from '@r-wasm/webr/chan/serviceworker';

function handleFetch(event){
    if(webRHandlers.handleFetch(event)){
      return;
    }
    console.log("A fetch occurred that's unrelated to webR!");
    // Other service worker work could be included here.
}

self.addEventListener('fetch', handleFetch);
```