### PR TITLE
Rename WebROptions properties to camelCase

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,12 @@
+# webR (development version)
+
+## Breaking changes
+ * Rename the properties of `WebROptions` so that they are all in camelCase, consistent with the rest of the webR TypeScript source. We have made the decision to release the above breaking change quickly while there are still a relatively low number of affected users.
+
+## Bug fixes
+
+ * Improve compatibility when running webR under Node (#167 & #171).
+
+# webR 0.1.0
+
+Initial Release

--- a/src/docs/downloading.qmd
+++ b/src/docs/downloading.qmd
@@ -25,7 +25,7 @@ await webR.init();
 
 The default location from which webR will load the WebAssembly R binaries depends on the execution environment. When running in a browser, webR will download binaries from CDN at start-up. If webR is running under Node.js, it will load binaries from the local module installation directory.
 
-If required, this behaviour can be overridden by self-hosting the contents of a [webR release package](#download-release) (or [building from source](#build-from-source)) and providing an alternative base URL for the [`WebROptions.WEBR_URL`](api/js/interfaces/WebR.WebROptions.md#webr_url) configuration setting.
+If required, this behaviour can be overridden by self-hosting the contents of a [webR release package](#download-release) (or [building from source](#build-from-source)) and providing an alternative base URL for the [`WebROptions.baseUrl`](api/js/interfaces/WebR.WebROptions.md#baseurl) configuration setting.
 
 ## Download from CDN
 

--- a/src/docs/serving.qmd
+++ b/src/docs/serving.qmd
@@ -62,4 +62,4 @@ saved with the filename `webr-worker.js`.
 
 Serve the two files somewhere in the same origin and scope as your web page. Do not store the scripts in a subdirectory relative to the page, as the service worker's scope would then be limited to that location.
 
-Once the worker scripts are available on your server, configure webR by giving the URL of the directory containing the scripts as the configuration option [`WebROptions.SW_URL`](api/js/interfaces/WebR.WebROptions.md#sw_url).
+Once the worker scripts are available on your server, configure webR by giving the URL of the directory containing the scripts as the configuration option [`WebROptions.serviceWorkerUrl`](api/js/interfaces/WebR.WebROptions.md#serviceworkerurl).

--- a/src/tests/console/console.test.ts
+++ b/src/tests/console/console.test.ts
@@ -13,7 +13,7 @@ const con = new Console(
     prompt: (line: string) => waitForPrompt.resolve(prompt(line)),
   },
   {
-    WEBR_URL: '../dist/',
+    baseUrl: '../dist/',
   }
 );
 con.run();

--- a/src/tests/packages/webr.test.ts
+++ b/src/tests/packages/webr.test.ts
@@ -2,7 +2,7 @@ import { WebR } from '../../webR/webr-main';
 import { RDouble, RLogical } from '../../webR/robj-main';
 
 const webR = new WebR({
-  WEBR_URL: '../dist/',
+  baseUrl: '../dist/',
   RArgs: ['--quiet'],
   interactive: false,
 });

--- a/src/tests/webR/proxy.test.ts
+++ b/src/tests/webR/proxy.test.ts
@@ -3,7 +3,7 @@ import { RDouble, RFunction, RList } from '../../webR/robj-main';
 import util from 'util';
 
 const webR = new WebR({
-  WEBR_URL: '../dist/',
+  baseUrl: '../dist/',
   RArgs: ['--quiet'],
 });
 

--- a/src/tests/webR/robj.test.ts
+++ b/src/tests/webR/robj.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../webR/robj-main';
 
 const webR = new WebR({
-  WEBR_URL: '../dist/',
+  baseUrl: '../dist/',
   RArgs: ['--quiet'],
 });
 

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../webR/robj-main';
 
 const webR = new WebR({
-  WEBR_URL: '../dist/',
+  baseUrl: '../dist/',
   RArgs: ['--quiet'],
 });
 

--- a/src/tests/webR/webr-r.test.ts
+++ b/src/tests/webR/webr-r.test.ts
@@ -1,7 +1,7 @@
 import { WebR } from '../../webR/webr-main';
 
 const webR = new WebR({
-  WEBR_URL: '../dist/',
+  baseUrl: '../dist/',
   RArgs: ['--quiet'],
 });
 

--- a/src/tests/webR/webr-worker.test.ts
+++ b/src/tests/webR/webr-worker.test.ts
@@ -2,7 +2,7 @@ import { WebR } from '../../webR/webr-main';
 import { RInteger, RLogical, RRaw } from '../../webR/robj-main';
 
 const webR = new WebR({
-  WEBR_URL: '../dist/',
+  baseUrl: '../dist/',
   RArgs: ['--quiet'],
 });
 

--- a/src/webR/chan/channel-common.ts
+++ b/src/webR/chan/channel-common.ts
@@ -43,7 +43,7 @@ export function newChannelMain(data: Required<WebROptions>) {
        * workers, we could setup a service worker to inject the relevant headers
        * to enable cross-origin isolation.
        */
-      if ('serviceWorker' in navigator && !isCrossOrigin(data.SW_URL)) {
+      if ('serviceWorker' in navigator && !isCrossOrigin(data.serviceWorkerUrl)) {
         return new ServiceWorkerChannelMain(data);
       }
       throw new Error("Can't initialise main thread communication channel");

--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -36,26 +36,28 @@ export class ServiceWorkerChannelMain extends ChannelMain {
     const initWorker = (worker: Worker) => {
       this.#handleEventsFromWorker(worker);
       this.close = () => worker.terminate();
-      this.#registerServiceWorker(`${config.SW_URL}webr-serviceworker.js`).then((clientId) => {
-        const msg = {
-          type: 'init',
-          data: {
-            config,
-            channelType: ChannelType.ServiceWorker,
-            clientId,
-            location: window.location.href,
-          },
-        } as Message;
-        worker.postMessage(msg);
-      });
+      this.#registerServiceWorker(`${config.serviceWorkerUrl}webr-serviceworker.js`).then(
+        (clientId) => {
+          const msg = {
+            type: 'init',
+            data: {
+              config,
+              channelType: ChannelType.ServiceWorker,
+              clientId,
+              location: window.location.href,
+            },
+          } as Message;
+          worker.postMessage(msg);
+        }
+      );
     };
 
-    if (isCrossOrigin(config.SW_URL)) {
-      newCrossOriginWorker(`${config.SW_URL}webr-worker.js`, (worker: Worker) =>
+    if (isCrossOrigin(config.serviceWorkerUrl)) {
+      newCrossOriginWorker(`${config.serviceWorkerUrl}webr-worker.js`, (worker: Worker) =>
         initWorker(worker)
       );
     } else {
-      const worker = new Worker(`${config.SW_URL}webr-worker.js`);
+      const worker = new Worker(`${config.serviceWorkerUrl}webr-worker.js`);
       initWorker(worker);
     }
 

--- a/src/webR/chan/channel-shared.ts
+++ b/src/webR/chan/channel-shared.ts
@@ -33,12 +33,12 @@ export class SharedBufferChannelMain extends ChannelMain {
       worker.postMessage(msg);
     };
 
-    if (isCrossOrigin(config.WEBR_URL)) {
-      newCrossOriginWorker(`${config.WEBR_URL}webr-worker.js`, (worker: Worker) =>
+    if (isCrossOrigin(config.baseUrl)) {
+      newCrossOriginWorker(`${config.baseUrl}webr-worker.js`, (worker: Worker) =>
         initWorker(worker)
       );
     } else {
-      const worker = new Worker(`${config.WEBR_URL}webr-worker.js`);
+      const worker = new Worker(`${config.baseUrl}webr-worker.js`);
       initWorker(worker);
     }
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -104,20 +104,20 @@ export interface WebROptions {
    * The base URL used for downloading R WebAssembly binaries.
    *  Default: `'https://webr.r-wasm.org/[version]/'`
    */
-  WEBR_URL?: string;
+  baseUrl?: string;
 
   /**
    * The repo URL to use when downloading R WebAssembly packages.
    * Default: `'https://repo.r-wasm.org/`
    */
-  PKG_URL?: string;
+  repoUrl?: string;
 
   /**
    * The base URL from where to load JavaScript worker scripts when loading
    * webR with the ServiceWorker communication channel mode.
    * Default: `''`
    */
-  SW_URL?: string;
+  serviceWorkerUrl?: string;
 
   /**
    * The WebAssembly user's home directory and initial working directory.
@@ -146,9 +146,9 @@ const defaultEnv = {
 const defaultOptions = {
   RArgs: [],
   REnv: defaultEnv,
-  WEBR_URL: BASE_URL,
-  SW_URL: '',
-  PKG_URL: PKG_BASE_URL,
+  baseUrl: BASE_URL,
+  serviceWorkerUrl: '',
+  repoUrl: PKG_BASE_URL,
   homedir: '/home/web_user',
   interactive: true,
   channelType: ChannelType.Automatic,

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -378,7 +378,7 @@ function dispatch(msg: Message): void {
 
           case 'installPackage': {
             // TODO: Use `evalRVoid()`
-            evalR(`webr::install("${reqMsg.data.name as string}", repos="${_config.PKG_URL}")`);
+            evalR(`webr::install("${reqMsg.data.name as string}", repos="${_config.repoUrl}")`);
 
             write({
               obj: true,
@@ -658,7 +658,7 @@ function init(config: Required<WebROptions>) {
       initPersistentObjects();
       chan?.setInterrupt(Module._Rf_onintr);
       Module.setValue(Module._R_Interactive, _config.interactive, '*');
-      evalR(`options(webr_pkg_repos="${_config.PKG_URL}")`);
+      evalR(`options(webr_pkg_repos="${_config.repoUrl}")`);
       chan?.resolve();
     },
 
@@ -695,7 +695,7 @@ function init(config: Required<WebROptions>) {
     },
   };
 
-  Module.locateFile = (path: string) => _config.WEBR_URL + path;
+  Module.locateFile = (path: string) => _config.baseUrl + path;
   Module.downloadFileContent = downloadFileContent;
 
   Module.print = (text: string) => {
@@ -716,7 +716,7 @@ function init(config: Required<WebROptions>) {
 
   // At the next tick, launch the REPL. This never returns.
   setTimeout(() => {
-    const scriptSrc = `${_config.WEBR_URL}R.bin.js`;
+    const scriptSrc = `${_config.baseUrl}R.bin.js`;
     loadScript(scriptSrc);
   });
 }


### PR DESCRIPTION
`WEBR_URL` -> `baseUrl`. This reads a little better to my eyes than `webRUrl`, and the context is clear enough since the interface is named `WebROptions`.

`PKG_URL` -> `repoUrl`. Since technically this points to a repository.

`SW_URL` -> `serviceWorkerUrl`.