### PR TITLE
Avoid `MAXLOC` in R's LAPACK distribution, fixing `chol()` when `pivot=TRUE`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
  * Improve compatibility when running webR under Node (#167 & #171).
 
+ * Fix `chol()` with `pivot=TRUE` by working around a Fortran library issue.
+
 # webR 0.1.0
 
 Initial Release

--- a/patches/R-4.1.3/emscripten-avoid-testing-issues.diff
+++ b/patches/R-4.1.3/emscripten-avoid-testing-issues.diff
@@ -1,22 +1,3 @@
-Index: R-4.1.3/src/library/base/man/chol.Rd
-===================================================================
---- R-4.1.3.orig/src/library/base/man/chol.Rd
-+++ R-4.1.3/src/library/base/man/chol.Rd
-@@ -114,6 +114,7 @@ qr(m)$rank # is 2, as it should be
- # chol() unlike qr() does not use a tolerance.
- try(chol(m))
- 
-+\dontrun{ # Throws a Fortran assertion error
- (Q <- chol(m, pivot = TRUE))
- ## we can use this by
- pivot <- attr(Q, "pivot")
-@@ -125,5 +126,6 @@ try(chol(m))  # fails
- (Q <- chol(m, pivot = TRUE)) # warning
- crossprod(Q)  # not equal to m
- }
-+}
- \keyword{algebra}
- \keyword{array}
 Index: R-4.1.3/src/library/base/man/stopifnot.Rd
 ===================================================================
 --- R-4.1.3.orig/src/library/base/man/stopifnot.Rd

--- a/patches/R-4.1.3/flang-avoid-maxloc.diff
+++ b/patches/R-4.1.3/flang-avoid-maxloc.diff
@@ -1,0 +1,102 @@
+Index: R-4.1.3/src/modules/lapack/dlapack.f
+===================================================================
+--- R-4.1.3.orig/src/modules/lapack/dlapack.f
++++ R-4.1.3/src/modules/lapack/dlapack.f
+@@ -114497,6 +114497,20 @@
+ *> \ingroup doubleOTHERcomputational
+ *
+ *  =====================================================================
++      INTEGER FUNCTION MAXLOCD( N, ARR )
++      INTEGER          I, N
++      DOUBLE PRECISION ARR( N ), TMP
++
++      MAXLOCD = 0
++      TMP = -HUGE(TMP)
++      DO I = 1, N
++         IF( ARR(I) > TMP) THEN
++            MAXLOCD = I
++            TMP = ARR(I)
++         END IF
++      END DO
++      END
++
+       SUBROUTINE DPSTF2( UPLO, N, A, LDA, PIV, RANK, TOL, WORK, INFO )
+ *
+ *  -- LAPACK computational routine (version 3.7.0) --
+@@ -114522,7 +114536,7 @@
+ *     ..
+ *     .. Local Scalars ..
+       DOUBLE PRECISION   AJJ, DSTOP, DTEMP
+-      INTEGER            I, ITEMP, J, PVT
++      INTEGER            I, ITEMP, J, PVT, MAXLOCD
+       LOGICAL            UPPER
+ *     ..
+ *     .. External Functions ..
+@@ -114534,7 +114549,7 @@
+       EXTERNAL           DGEMV, DSCAL, DSWAP, XERBLA
+ *     ..
+ *     .. Intrinsic Functions ..
+-      INTRINSIC          MAX, SQRT, MAXLOC
++      INTRINSIC          MAX, SQRT
+ *     ..
+ *     .. Executable Statements ..
+ *
+@@ -114615,7 +114630,7 @@
+   120       CONTINUE
+ *
+             IF( J.GT.1 ) THEN
+-               ITEMP = MAXLOC( WORK( (N+J):(2*N) ), 1 )
++               ITEMP = MAXLOCD(1+(2*N)-(N+J), WORK((N+J):(2*N)))
+                PVT = ITEMP + J - 1
+                AJJ = WORK( N+PVT )
+                IF( AJJ.LE.DSTOP.OR.DISNAN( AJJ ) ) THEN
+@@ -114678,7 +114693,7 @@
+   140       CONTINUE
+ *
+             IF( J.GT.1 ) THEN
+-               ITEMP = MAXLOC( WORK( (N+J):(2*N) ), 1 )
++               ITEMP = MAXLOCD(1+(2*N)-(N+J), WORK((N+J):(2*N)))
+                PVT = ITEMP + J - 1
+                AJJ = WORK( N+PVT )
+                IF( AJJ.LE.DSTOP.OR.DISNAN( AJJ ) ) THEN
+@@ -114909,7 +114924,7 @@
+ *     ..
+ *     .. Local Scalars ..
+       DOUBLE PRECISION   AJJ, DSTOP, DTEMP
+-      INTEGER            I, ITEMP, J, JB, K, NB, PVT
++      INTEGER            I, ITEMP, J, JB, K, NB, PVT, MAXLOCD
+       LOGICAL            UPPER
+ *     ..
+ *     .. External Functions ..
+@@ -114922,12 +114937,12 @@
+       EXTERNAL           DGEMV, DPSTF2, DSCAL, DSWAP, DSYRK, XERBLA
+ *     ..
+ *     .. Intrinsic Functions ..
+-      INTRINSIC          MAX, MIN, SQRT, MAXLOC
++      INTRINSIC          MAX, MIN, SQRT
+ *     ..
+ *     .. Executable Statements ..
+ *
+ *     Test the input parameters.
+ *
+       INFO = 0
+       UPPER = LSAME( UPLO, 'U' )
+       IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
+@@ -115024,7 +115036,7 @@
+   120             CONTINUE
+ *
+                   IF( J.GT.1 ) THEN
+-                     ITEMP = MAXLOC( WORK( (N+J):(2*N) ), 1 )
++                     ITEMP = MAXLOCD(1+(2*N)-(N+J), WORK((N+J):(2*N)))
+                      PVT = ITEMP + J - 1
+                      AJJ = WORK( N+PVT )
+                      IF( AJJ.LE.DSTOP.OR.DISNAN( AJJ ) ) THEN
+@@ -115111,7 +115123,7 @@
+   160             CONTINUE
+ *
+                   IF( J.GT.1 ) THEN
+-                     ITEMP = MAXLOC( WORK( (N+J):(2*N) ), 1 )
++                     ITEMP = MAXLOCD(1+(2*N)-(N+J), WORK((N+J):(2*N)))
+                      PVT = ITEMP + J - 1
+                      AJJ = WORK( N+PVT )
+                      IF( AJJ.LE.DSTOP.OR.DISNAN( AJJ ) ) THEN

--- a/patches/R-4.1.3/series
+++ b/patches/R-4.1.3/series
@@ -18,3 +18,4 @@ emscripten-xhr-download.diff
 fix-signrank-wilcox.diff
 emscripten-avoid-testing-issues.diff
 fix-dtptrs.diff
+flang-avoid-maxloc.diff


### PR DESCRIPTION
Last week I spent some time attempting to debug the cause of #170. This PR summaries my findings and describes a resulting fix for the previously broken R function `chol(..., pivot=TRUE)`.

The `RUNTIME_CHECK(catKind.has_value())` crash in `extrema.cpp` comes from the LLVM fortran runtime, in the intrinsic function `MAXLOC`. The functions `MINLOC`, `MAXVAL`, `MINVAL` and probably others are also affected by the same bug.

The affected runtime functions take in fortran arrays in the form of so-called descriptors, which can be thought of as a struct containing a pointer to the array along with some additional information. The process of taking a fortran array and creating a descriptor is known as [emboxing](https://flang.llvm.org/docs/FIRLangRef.html#fir-embox-fir-emboxop).

There seems to be at least two related LLVM flang issues. The first, in FIR generation, is that the type information for the emboxed array elements is dropped when invoking a function. Indeed by taking a look at the generated FIR for a `MAXLOC` call we can see that the type of the elements of the array, `?xf64`, is cast to `none` before the call to `_FortranAMaxlocDim`.

```
%235 = fir.embox %234 : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
fir.store %235 to %29 : !fir.ref<!fir.box<!fir.heap<i32>>>
%236 = fir.address_of(@_QQcl.24142151609af5b892f44f877601ca1f) : !fir.ref<!fir.char<1,43>>
%237 = fir.convert %29 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
%238 = fir.convert %232 : (!fir.box<!fir.array<?xf64>>) -> !fir.box<none>
%239 = fir.convert %c4 : (index) -> i32
%240 = fir.convert %236 : (!fir.ref<!fir.char<1,43>>) -> !fir.ref<i8>
%241 = fir.convert %233 : (!fir.box<i1>) -> !fir.box<none>
%242 = fir.call @_FortranAMaxlocDim(%237, %238, %239, %c1_i32, %240, %c114633_i32, %241, %false) : (!fir.ref<!fir.box<none>>, !fir.box<none>, i32, i32, !fir.ref<i8>, i32, !fir.box<none>, i1) -> none
```

This issue can be patched by hand, but it turns out to be insufficient. A further issue is that at least in some cases the `fir.embox` operation outputs machine code that fails to allocate memory for and populate the additional information attached to the descriptor, which should contain the array's length, the `TYPE`, and the `KIND` of the elements of the emboxed array. The implmentation of `MAXLOC` (and others) try to use this additional information to decide how to proceed at runtime, leading to the crash.

It looks like these issues are already known and being worked on, with [relevant commits as recent as Jan 10](https://github.com/llvm/llvm-project/commit/dbee2030a5651d76b543f2b3275489c3e049df05) in the main LLVM repo. I tried cherry-picking into the `f18-llvm-project` repo a selection of commits over the last year or so working on the FIR emboxing and descriptor generation code, but without success. I think we will have to wait until the work in the `fir-dev` branch we are currently based on is fully upstreamed into LLVM so that we can then upgrade and pick up these fixes and improvements that way. I tried the recent LLVM 16 release without succcess, but perhaps the work will be done by the time LLVM 17 arrives.

In the meantime, this PR patches R's distribution of LAPACK so as to avoid using `MAXLOC`. LAPACK only seems to use a small subset of `MAXLOC`s features, and only for `DOUBLE PRECISION` arrays. So, we can avoid it by reimplementing a similar function ourselves. The change fixes the R `chol()` function, so I have also removed the patch that ignores the test of `chol()` in the base R package tests.

This change does help with #170, but there still seems to be some other numerical stability issues going on, so there is still further work to be done before that issue can be closed.