### PR TITLE
detect the availability of `SharedArrayBuffer`

### DIFF
--- a/src/webR/chan/channel-common.ts
+++ b/src/webR/chan/channel-common.ts
@@ -2,7 +2,6 @@ import { SharedBufferChannelMain, SharedBufferChannelWorker } from './channel-sh
 import { ServiceWorkerChannelMain, ServiceWorkerChannelWorker } from './channel-service';
 import { WebROptions } from '../webr-main';
 import { isCrossOrigin } from '../utils';
-import { IN_NODE } from '../compat';
 
 // This file refers to objects imported from `./channel-shared` and
 // `./channel-service.` These can't be included in `./channel` as this
@@ -35,7 +34,7 @@ export function newChannelMain(data: Required<WebROptions>) {
       return new ServiceWorkerChannelMain(data);
     case ChannelType.Automatic:
     default:
-      if ("SharedArrayBuffer" in globalThis) {
+      if (typeof SharedArrayBuffer !== 'undefined') {
         return new SharedBufferChannelMain(data);
       }
       /*

--- a/src/webR/chan/channel-common.ts
+++ b/src/webR/chan/channel-common.ts
@@ -35,7 +35,7 @@ export function newChannelMain(data: Required<WebROptions>) {
       return new ServiceWorkerChannelMain(data);
     case ChannelType.Automatic:
     default:
-      if (IN_NODE || crossOriginIsolated) {
+      if ("SharedArrayBuffer" in globalThis) {
         return new SharedBufferChannelMain(data);
       }
       /*


### PR DESCRIPTION
Great project! Thank you.

This PR checks the availability of `SharedArrayBuffer` instead of checking environment (node) and cross-origin isolation. 

This allows using `SharedArrayBuffer` in chrome with [origin trial](https://developer.chrome.com/blog/enabling-shared-array-buffer/#origin-trial) in pages which are not cross-origin isolated.