### PR TITLE
fix minor typos

### DIFF
--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -25,12 +25,12 @@ export interface CallRObjectMethodMessage extends Message {
 export interface EvalROptions {
   /**
    * The R environment to evaluate within.
-   * Deafult: The global environment.
+   * Default: The global environment.
    */
   env?: WebRData;
   /**
    * Should the stdout and stderr output streams be captured and returned?
-   * Deafult: `true`.
+   * Default: `true`.
    */
   captureStreams?: boolean;
   /**
@@ -45,12 +45,12 @@ export interface EvalROptions {
   withAutoprint?: boolean;
   /**
    * Should an R error condition be re-thrown as a JavaScript exception?
-   * Deafult: `true`.
+   * Default: `true`.
    */
   throwJsException?: boolean;
   /**
    * Should the code be executed using a `tryCatch` with handlers in place?
-   * Deafult: `true`.
+   * Default: `true`.
    */
   withHandlers?: boolean;
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -133,7 +133,7 @@ export interface WebROptions {
 
   /**
    * Set the communication channel type to be used.
-   * Deafult: `channelType.Automatic`
+   * Default: `channelType.Automatic`
    */
   channelType?: (typeof ChannelType)[keyof typeof ChannelType];
 }


### PR DESCRIPTION
This PR just fixes minor typos in JSDoc comments.

I believe that is used for [auto-generated docs](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebRChan.EvalROptions.html#capturestreams).