### PR TITLE
Create a "system" queue for non-user-facing output messages

### DIFF
--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -164,6 +164,10 @@ export class ServiceWorkerChannelMain extends ChannelMain {
         this.resolveResponse(message as Response);
         return;
 
+      case 'system':
+        this.systemQueue.put(message.data as Message);
+        return;
+
       default:
         this.outputQueue.put(message);
         return;
@@ -210,6 +214,10 @@ export class ServiceWorkerChannelWorker implements ChannelWorker {
 
   write(msg: Message, transfer?: [Transferable]) {
     this.#ep.postMessage(msg, transfer);
+  }
+
+  writeSystem(msg: Message, transfer?: [Transferable]) {
+    this.#ep.postMessage({ type: 'system', data: msg }, transfer);
   }
 
   syncRequest(message: Message): Response {

--- a/src/webR/chan/channel-shared.ts
+++ b/src/webR/chan/channel-shared.ts
@@ -78,6 +78,10 @@ export class SharedBufferChannelMain extends ChannelMain {
         this.resolveResponse(message as Response);
         return;
 
+      case 'system':
+        this.systemQueue.put(message.data as Message);
+        return;
+
       default:
         this.outputQueue.put(message);
         return;
@@ -129,6 +133,10 @@ export class SharedBufferChannelWorker implements ChannelWorker {
 
   write(msg: Message, transfer?: [Transferable]) {
     this.#ep.postMessage(msg, transfer);
+  }
+
+  writeSystem(msg: Message, transfer?: [Transferable]) {
+    this.#ep.postMessage({ type: 'system', data: msg }, transfer);
   }
 
   read(): Message {

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -31,6 +31,7 @@ import { WebRPayload, WebRPayloadWorker, webRPayloadError } from '../payload';
 export abstract class ChannelMain {
   inputQueue = new AsyncQueue<Message>();
   outputQueue = new AsyncQueue<Message>();
+  systemQueue = new AsyncQueue<Message>();
 
   #parked = new Map<string, { resolve: ResolveFn; reject: RejectFn }>();
 
@@ -48,6 +49,10 @@ export abstract class ChannelMain {
       msg.push(await this.read());
     }
     return msg;
+  }
+
+  async readSystem(): Promise<Message> {
+    return await this.systemQueue.get();
   }
 
   write(msg: Message): void {
@@ -86,6 +91,7 @@ export abstract class ChannelMain {
 export interface ChannelWorker {
   resolve(): void;
   write(msg: Message, transfer?: [Transferable]): void;
+  writeSystem(msg: Message, transfer?: [Transferable]): void;
   read(): Message;
   handleInterrupt(): void;
   setInterrupt(interrupt: () => void): void;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -706,7 +706,7 @@ function init(config: Required<WebROptions>) {
     },
 
     setTimeoutWasm: (ptr: EmPtr, delay: number, ...args: number[]): void => {
-      chan?.write({ type: 'setTimeoutWasm', data: { ptr, delay, args } });
+      chan?.writeSystem({ type: 'setTimeoutWasm', data: { ptr, delay, args } });
     },
   };
 


### PR DESCRIPTION
This is a modification of PR #146.

As pointed out by Lionel, the implementation of #146 means that users need to mill through messages sitting in the output queue (even just to throw them away) so that timeout messages are handled properly. In addition, I noticed that using `flush()` would skip past the special handler.

This PR attempts to deal with both issues by maintaining a second queue on the main thread. The intention is for this queue to act as a side-channel for non-output messages. i.e. messages such as the new `setTimeoutWasm` type that are not intended to be consumed by the end user, but are used by webR internally

Since the end user will never need to see these messages, I have named this queue the "system" queue, and it is handled by webR itself in a private async infloop, which starts spinning on invocation of `webR.init()`.

I can't immediately see a downside with this approach over the in-band messaging of #146, but I put together this alternative quickly and could have missed something obvious, thus the separate PR.