### PR TITLE
Propagate R interruption caught in `Module.webr.evalJs`

### DIFF
--- a/src/tests/console/console.test.ts
+++ b/src/tests/console/console.test.ts
@@ -38,15 +38,25 @@ test('Generate an error message and write to stdout', async () => {
   expect(stderr).toHaveBeenCalledWith('Error: unexpected \';\' in ";"');
 });
 
-test('Interrupt a long running R computation', async () => {
-  waitForPrompt = promiseHandles();
-  con.stdin('while(TRUE){}');
-  con.interrupt();
-  // A new prompt will appear only if the infinite loop is successfully interrupted
-  await waitForPrompt.promise;
-  expect(prompt).toHaveBeenCalledWith('> ');
-});
+describe('Interrupt execution', () => {
+  test('Interrupt R code executed using the main R REPL', async () => {
+    waitForPrompt = promiseHandles();
+    con.stdin('while(TRUE){}');
+    con.interrupt();
+    // A new prompt will appear only if the infinite loop is successfully interrupted
+    await waitForPrompt.promise;
+    expect(prompt).toHaveBeenCalledWith('> ');
+  });
 
+  test('Interrupt webr::eval_js executed using the main R REPL', async () => {
+    waitForPrompt = promiseHandles();
+    con.stdin('webr::eval_js("globalThis.Module.webr.readConsole()")');
+    con.interrupt();
+    // A new prompt will appear only if the infinite loop is successfully interrupted
+    await waitForPrompt.promise;
+    expect(prompt).toHaveBeenCalledWith('> ');
+  });
+});
 afterAll(() => {
   return con.webR.close();
 });

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -617,6 +617,20 @@ describe('Evaluate objects without shelters', () => {
   });
 });
 
+describe('Interrupt execution', () => {
+  test('Interrupt R code executed using evalR', async () => {
+    const loop = webR.evalRVoid('while(TRUE){}');
+    setTimeout(() => webR.interrupt(), 100);
+    await expect(loop).rejects.toThrow('A non-local transfer of control occured');
+  });
+
+  test('Interrupt webr::eval_js executed using evalR', async () => {
+    const loop = webR.evalRVoid('webr::eval_js("globalThis.Module.webr.readConsole()")');
+    setTimeout(() => webR.interrupt(), 100);
+    await expect(loop).rejects.toThrow('A non-local transfer of control occured');
+  });
+});
+
 test('Invoke a wasm function from the main thread', async () => {
   const ptr = (await webR.evalRNumber(`
     webr::eval_js("

--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -129,6 +129,7 @@ export class ServiceWorkerChannelMain extends ChannelMain {
             uuid: uuid,
             response: newResponse(uuid, response),
           });
+          this.inputQueue.reset();
           this.#interrupted = false;
           break;
         }

--- a/src/webR/chan/channel-shared.ts
+++ b/src/webR/chan/channel-shared.ts
@@ -49,6 +49,7 @@ export class SharedBufferChannelMain extends ChannelMain {
     if (!this.#interruptBuffer) {
       throw new Error('Failed attempt to interrupt before initialising interruptBuffer');
     }
+    this.inputQueue.reset();
     this.#interruptBuffer[0] = 1;
   }
 

--- a/src/webR/chan/queue.ts
+++ b/src/webR/chan/queue.ts
@@ -16,6 +16,11 @@ export class AsyncQueue<T> {
     this.#promises = [];
   }
 
+  reset() {
+    this.#resolvers = [];
+    this.#promises = [];
+  }
+
   put(t: T) {
     if (!this.#resolvers.length) {
       this.#add();

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -695,6 +695,9 @@ function init(config: Required<WebROptions>) {
         if (e instanceof UnwindProtectException) {
           Module._R_ContinueUnwind(e.cont);
           throwUnreachable();
+        } else if (e === Infinity) {
+          // Propagate interruption
+          throw e;
         }
         const msg = Module.allocateUTF8OnStack(
           `An error occured during JavaScript evaluation:\n  ${(e as { message: string }).message}`


### PR DESCRIPTION
When running JS code from within R using `webr::eval_js()`, unwind protection is used. An R error is handled by catching a continuation token as the stack unwinds. In the current code it is assumed that any other exception was caused by an error during JavaScript evaluation and is converted into an R error using `Rf_error()`.

There is another reasonable possibility: interrupting webR using `WebR.interrupt()` calls R's `onintr()` function, leading to a non-local transfer of control, implemented by Emscripten by throwing an exception with a value of `Infinity`.

This PR catches that particular case and propagates the interruption by rethrowing the exception directly.

Note: For me this situation has only come up once: running a version of the httpuv package in webR. In the experimental httpuv package, R waits for JS messages to arrive containing HTTP request information, using `webr::eval_js()`, and it is here the interruption can occur.