### PR TITLE
Build Cairo graphics library and its prerequisites, statically linking with webR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted universe"
     echo "deb http://security.ubuntu.com/ubuntu/ trusty-security main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get -y install --no-install-recommends \
-        build-essential curl wget git gnutls-bin bash make cmake ca-certificates xz-utils \
+        build-essential curl wget git gnutls-bin bash make cmake ca-certificates xz-utils gperf \
         gfortran-4.6 g++-4.6 gcc-4.6 gcc-4.6-plugin-dev gfortran-4.6 llvm-3.3-dev python3 quilt \
 		libbz2-dev liblzma-dev libpcre2-dev libcurl4-openssl-dev libpng-dev clang-3.3 zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -10,6 +10,7 @@ The following external software is included either directly as part of this repo
  * [Dragonegg](https://dragonegg.llvm.org) - GNU GPL Version 2
  * [LLVM Flang](https://github.com/flang-compiler/f18-llvm-project) - Apache Licence Version 2
  * [xterm.js](https://xtermjs.org/) - MIT Licence
+ * [Noto Fonts](https://fonts.google.com/noto) - SIL Open Font License
 
 The webR distribution binaries also contain copies of several of the above software. To remain compatible with the GPL, the webR binaries are distributed under the GNU GPL Version 3 Licence (copied below).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Improve accessibility of xterm.js in the webR REPL app by enabling `screenReaderMode`.
 * Issue an output message of type `'closed'` when the webR communication channel closes.
+* Build Cairo graphics library and its prerequisites for Wasm as part of the webR build process. This allows the default Cairo-based graphics devices in R, such as `png()`, `bmp()` and `svg()`, to work in webR.
 
 # webR 0.1.1
 

--- a/R/Makefile
+++ b/R/Makefile
@@ -76,7 +76,7 @@ $(BUILD)/state/r-stage1-configured: $(BUILD)/state/r-patched
 	    --with-aqua=no \
 	    --with-readline=no \
 	    --with-jpeglib=no \
-	    --with-cairo=no \
+	    --with-static-cairo=yes \
 	    --disable-openmp \
 	    --with-recommended-packages=no \
 	    --enable-R-profiling=no \
@@ -97,12 +97,14 @@ STAGE2_CPPFLAGS += -I$(WASM)/include
 STAGE2_CPPFLAGS += -DEXPEL_OLD_TO_NEW=1
 STAGE2_CPPFLAGS += -s USE_BZIP2=1
 STAGE2_CPPFLAGS += -s USE_ZLIB=1
+STAGE2_CPPFLAGS += -s USE_FREETYPE=1
 
 STAGE2_CFLAGS := $(STAGE2_CFLAGS)
 STAGE2_CFLAGS += $(STAGE2_CPPFLAGS) $(WASM_CFLAGS)
 
 STAGE2_LDFLAGS := $(STAGE2_LDFLAGS)
 STAGE2_LDFLAGS += -L$(WASM)/lib
+STAGE2_LDFLAGS +=-s USE_FREETYPE=1
 
 MAIN_LDFLAGS  = -s MAIN_MODULE=1
 MAIN_LDFLAGS += -s WASM=1
@@ -138,7 +140,7 @@ $(BUILD)/state/r-stage2-configured: $(BUILD)/state/r-patched $(FORTRAN_WASM_LIB)
 	    --with-x=no \
 	    --with-readline=no \
 	    --with-jpeglib=no \
-	    --with-cairo=no \
+	    --with-static-cairo=yes \
 	    --disable-openmp \
 	    --with-recommended-packages=no \
 	    --enable-R-profiling=no \
@@ -176,6 +178,10 @@ MAKE_WASM_INSTALL := $(MAKE_WASM)
 $(BUILD)/state/r-stage2: $(BUILD)/state/r-stage1 $(BUILD)/state/r-stage2-configured
 	cd $(WEBR_ROOT)/packages && \
 	  $(MAKE_WASM) clean && $(MAKE_WASM) all
+# Remove repeated link flags, leads to duplicate symbol error with Emscripten
+	sed -i.bak -e ':m' -e 's/-lz//2' -e 't m' -e ':n' -e 's/-lpng16//2' -e 't n' \
+	  $(R_SOURCE)/build/src/library/grDevices/src/cairo/Makefile
+	rm $(R_SOURCE)/build/src/library/grDevices/src/cairo/Makefile.bak
 	cd $(STAGE2_BUILD) && \
 	  $(MAKE_WASM_BUILD) R
 	touch $@

--- a/R/Makefile
+++ b/R/Makefile
@@ -190,6 +190,7 @@ $(BUILD)/state/r-stage2: $(BUILD)/state/r-stage1 $(BUILD)/state/r-stage2-configu
 Rprofile: $(BUILD)/state/r-stage2
 	mkdir -p "$(R_WASM)/lib/R/etc/"
 	echo "options(expressions=400)" > "$(R_WASM)/lib/R/etc/Rprofile.site"
+	echo "options(bitmapType='cairo')" >> "$(R_WASM)/lib/R/etc/Rprofile.site"
 
 .PHONY: install
 install: install-tests Rprofile

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ R's source code and supporting libraries are written in both C/C++ and Fortran. 
 If you are compiling webR using the default toolchain, ensure that you first install the following required prerequisites:
  * [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html) (>=3.1.25)
  * cmake
+ * gperf
  * liblzma
  * libpcre2
  * node (>=16.0.0)

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -15,24 +15,119 @@ WASM_CFLAGS := $(WASM_CFLAGS)
 WASM_CFLAGS += -fPIC -fno-exceptions -fno-rtti $(WASM_OPT)
 WASM_CFLAGS += -s USE_BZIP2=1 -s USE_ZLIB=1
 
+CAIRO_VERSION = 1.14.12
+CAIRO_TARBALL = $(DOWNLOAD)/cairo-$(CAIRO_VERSION).tar.xz
+CAIRO_URL = https://cairographics.org/releases/cairo-${CAIRO_VERSION}.tar.xz
+CAIRO_WASM_LIB = $(WASM)/lib/libcairo.a
+
+FC_VERSION = 2.13.92
+FC_TARBALL = $(DOWNLOAD)/fontconfig-$(FC_VERSION).tar.gz
+FC_URL = https://www.freedesktop.org/software/fontconfig/release/fontconfig-$(FC_VERSION).tar.gz
+FC_WASM_LIB = $(WASM)/lib/libfontconfig.a
+
 LIBPNG_VERSION = 1.6.38
 LIBPNG_TARBALL = $(DOWNLOAD)/libpng-$(LIBPNG_VERSION).tar.gz
 LIBPNG_URL = http://prdownloads.sourceforge.net/libpng/libpng-$(LIBPNG_VERSION).tar.xz?download
 LIBPNG_WASM_LIB = $(WASM)/lib/libpng.a
+
+LIBXML2_VERSION = 2.10.3
+LIBXML2_WORDS = $(subst ., ,$(LIBXML2_VERSION))
+LIBXML2_SHORT := $(word 1,$(LIBXML2_WORDS)).$(word 2,$(LIBXML2_WORDS))
+LIBXML2_TARBALL = $(DOWNLOAD)/libxml2-$(LIBXML2_VERSION).tar.xz
+LIBXML2_URL = https://download.gnome.org/sources/libxml2/$(LIBXML2_SHORT)/libxml2-$(LIBXML2_VERSION).tar.xz
+LIBXML2_WASM_LIB = $(WASM)/lib/libxml2.a
 
 PCRE_VERSION = 10.39
 PCRE_TARBALL = $(DOWNLOAD)/pcre2-$(PCRE_VERSION).tar.gz
 PCRE_URL = https://github.com/PhilipHazel/pcre2/releases/download/pcre2-${PCRE_VERSION}/pcre2-$(PCRE_VERSION).tar.gz
 PCRE_WASM_LIB = $(WASM)/lib/libpcre2-8.a
 
+PIXMAN_VERSION = 0.38.4
+PIXMAN_TARBALL = $(DOWNLOAD)/pixman-$(PIXMAN_VERSION).tar.gz
+PIXMAN_URL = https://cairographics.org/releases/pixman-$(PIXMAN_VERSION).tar.gz
+PIXMAN_WASM_LIB = $(WASM)/lib/libpixman-1.a
+
 XZ_VERSION = 5.2.5
 XZ_TARBALL = $(DOWNLOAD)/xz-$(XZ_VERSION).tar.gz
 XZ_URL = https://tukaani.org/xz/xz-$(XZ_VERSION).tar.gz/download
 XZ_WASM_LIB = $(WASM)/lib/liblzma.a
 
-WASM_LIBS = $(LIBPNG_WASM_LIB) $(PCRE_WASM_LIB) $(XZ_WASM_LIB)
+WASM_LIBS := $(CAIRO_WASM_LIB)
+WASM_LIBS += $(FC_WASM_LIB)
+WASM_LIBS += $(LIBPNG_WASM_LIB)
+WASM_LIBS += $(LIBXML2_WASM_LIB)
+WASM_LIBS += $(PCRE_WASM_LIB)
+WASM_LIBS += $(PIXMAN_WASM_LIB)
+WASM_LIBS += $(XZ_WASM_LIB)
 
 all: $(WASM_LIBS)
+
+.PHONY: cairo
+cairo: $(CAIRO_WASM_LIB)
+
+$(CAIRO_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget -q -O $@ $(CAIRO_URL)
+
+$(CAIRO_WASM_LIB): $(CAIRO_TARBALL) $(PIXMAN_WASM_LIB) $(FC_WASM_LIB)
+	rm -rf $(BUILD)/cairo-$(CAIRO_VERSION)
+	tar -C $(BUILD) -xf $(CAIRO_TARBALL)
+	cp -r "$(WEBR_ROOT)/patches/cairo-$(CAIRO_VERSION)/." \
+	  "$(BUILD)/cairo-$(CAIRO_VERSION)/patches"
+	cd "$(BUILD)/cairo-$(CAIRO_VERSION)" && quilt push -a
+	mkdir -p $(BUILD)/cairo-$(CAIRO_VERSION)/build
+	cd $(BUILD)/cairo-$(CAIRO_VERSION)/build && \
+	  CFLAGS="$(WASM_CFLAGS) -DCAIRO_NO_MUTEX=1" \
+	  LDFLAGS="-sUSE_FREETYPE=1" \
+	  FREETYPE_CFLAGS="-sUSE_FREETYPE=1" \
+	  FREETYPE_LIBS="-sUSE_FREETYPE=1" \
+	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
+	  emconfigure ../configure \
+	    ax_cv_c_float_words_bigendian=no \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --enable-pthread=no \
+	    --enable-ft=yes \
+	    --enable-fc=yes \
+	    --prefix=$(WASM) && \
+	  emmake make install
+	sed -i.bak -e 's/freetype2 >= [0-9]*\.[0-9]*\.[0-9]*//g' \
+		-e 's/-lz//2' $(WASM)/lib/pkgconfig/cairo.pc
+	sed -i.bak -e 's/freetype2 >= [0-9]*\.[0-9]*\.[0-9]*//g' $(WASM)/lib/pkgconfig/cairo-ft.pc
+	touch $@
+
+.PHONY: fontconfig
+fontconfig: $(FC_WASM_LIB)
+
+$(FC_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget -q -O $@ $(FC_URL)
+
+$(FC_WASM_LIB): $(FC_TARBALL) $(LIBXML2_WASM_LIB)
+	mkdir -p $(BUILD)
+	tar -C $(BUILD) -xf $(FC_TARBALL)
+	mkdir -p $(BUILD)/fontconfig-$(FC_VERSION)/build
+	sed -i.bak 's/ax_pthread_ok=yes/ax_pthread_ok=no/g' \
+	  $(BUILD)/fontconfig-$(FC_VERSION)/configure
+	sed -i.bak 's/RUN_FC_CACHE_TEST =.*/RUN_FC_CACHE_TEST = false/g' \
+	  $(BUILD)/fontconfig-$(FC_VERSION)/Makefile.in
+	cd $(BUILD)/fontconfig-$(FC_VERSION)/build && \
+	  CFLAGS="$(WASM_CFLAGS)" \
+	  FREETYPE_CFLAGS="-sUSE_FREETYPE=1" \
+	  FREETYPE_LIBS="-sUSE_FREETYPE=1" \
+	  LDFLAGS="-sUSE_FREETYPE=1" \
+	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
+	  emconfigure ../configure \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --enable-libxml2 \
+	    --prefix=$(WASM)
+	sed -i.bak 's/#define HAVE_FSTATFS 1/#undef HAVE_FSTATFS/' \
+	  $(BUILD)/fontconfig-$(FC_VERSION)/build/config.h
+	cd $(BUILD)/fontconfig-$(FC_VERSION)/build && \
+	  emmake make install
+	sed -i.bak 's/Requires:.*/Requires:/' $(WASM)/lib/pkgconfig/fontconfig.pc
+	touch $@
 
 .PHONY: libpng
 libpng: $(LIBPNG_WASM_LIB)
@@ -50,6 +145,29 @@ $(LIBPNG_WASM_LIB): $(LIBPNG_TARBALL)
 	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
 	    --enable-shared=no \
 	    --enable-static=yes \
+	    --prefix=$(WASM) && \
+	  emmake make install
+	touch $@
+
+.PHONY: libxml2
+libxml2: $(LIBXML2_WASM_LIB)
+
+$(LIBXML2_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget -q -O $@ $(LIBXML2_URL)
+
+$(LIBXML2_WASM_LIB): $(LIBXML2_TARBALL) $(ZLIB_WASM_LIB) $(XZ_WASM_LIB)
+	mkdir -p $(BUILD)
+	tar -C $(BUILD) -xf $(LIBXML2_TARBALL)
+	mkdir -p $(BUILD)/libxml2-$(LIBXML2_VERSION)/build
+	cd $(BUILD)/libxml2-$(LIBXML2_VERSION)/build && \
+	  CFLAGS="$(WASM_CFLAGS)" \
+	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
+	  emconfigure ../configure \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --without-python \
+	    --without-threads \
 	    --prefix=$(WASM) && \
 	  emmake make install
 	touch $@
@@ -73,6 +191,27 @@ $(PCRE_WASM_LIB): $(PCRE_TARBALL)
 	  emmake make install
 	touch $@
 
+.PHONY: pixman
+pixman: $(PIXMAN_WASM_LIB)
+
+$(PIXMAN_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget -q -O $@ $(PIXMAN_URL)
+
+$(PIXMAN_WASM_LIB): $(PIXMAN_TARBALL) $(LIBPNG_WASM_LIB)
+	tar -C $(BUILD) -xf $(PIXMAN_TARBALL)
+	mkdir -p $(BUILD)/pixman-$(PIXMAN_VERSION)/build
+	sed -i.bak 's/support_for_pthreads=yes/support_for_pthreads=no/g' \
+	  $(BUILD)/pixman-$(PIXMAN_VERSION)/configure
+	cd $(BUILD)/pixman-$(PIXMAN_VERSION)/build && \
+	  CFLAGS="$(WASM_CFLAGS)" \
+	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
+	  emconfigure ../configure \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --prefix=$(WASM) && \
+	  emmake make install
+
 .PHONY: xz
 xz: $(XZ_WASM_LIB)
 
@@ -89,6 +228,7 @@ $(XZ_WASM_LIB): $(XZ_TARBALL)
 	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
 	    --enable-shared=no \
 	    --enable-static=yes \
+	    --enable-threads=no \
 	    --prefix=$(WASM) && \
 	  emmake make install
 	touch $@

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -2,6 +2,7 @@ WEBR_ROOT = $(abspath ..)
 ROOT = $(abspath .)
 
 DOWNLOAD = $(ROOT)/download
+FONTS = $(DOWNLOAD)/fonts
 BUILD = $(ROOT)/build
 DIST = $(WEBR_ROOT)/dist
 TOOLS = $(WEBR_ROOT)/tools
@@ -60,7 +61,7 @@ WASM_LIBS += $(PCRE_WASM_LIB)
 WASM_LIBS += $(PIXMAN_WASM_LIB)
 WASM_LIBS += $(XZ_WASM_LIB)
 
-all: $(WASM_LIBS)
+all: $(WASM_LIBS) $(WASM)/usr/share/fonts
 
 .PHONY: cairo
 cairo: $(CAIRO_WASM_LIB)
@@ -232,6 +233,33 @@ $(XZ_WASM_LIB): $(XZ_TARBALL)
 	    --prefix=$(WASM) && \
 	  emmake make install
 	touch $@
+
+.PHONY: fonts
+fonts: $(WASM)/usr/share/fonts
+
+$(WASM)/usr/share/fonts:
+	mkdir -p "$(FONTS)" "$(WASM)/usr/share/fonts" "$(WASM)/etc/fonts/"
+	wget -O $(FONTS)/NotoSans.zip https://fonts.google.com/download?family=Noto%20Sans
+	unzip -p $(FONTS)/NotoSans.zip NotoSans-Regular.ttf > $(FONTS)/NotoSans-Regular.ttf
+	unzip -p $(FONTS)/NotoSans.zip NotoSans-Bold.ttf > $(FONTS)/NotoSans-Bold.ttf
+	unzip -p $(FONTS)/NotoSans.zip NotoSans-Italic.ttf > $(FONTS)/NotoSans-Italic.ttf
+	unzip -p $(FONTS)/NotoSans.zip NotoSans-BoldItalic.ttf > $(FONTS)/NotoSans-BoldItalic.ttf
+	rm $(FONTS)/NotoSans.zip
+	wget -O $(FONTS)/NotoSerif.zip https://fonts.google.com/download?family=Noto%20Serif
+	unzip -p $(FONTS)/NotoSerif.zip NotoSerif-Regular.ttf > $(FONTS)/NotoSerif-Regular.ttf
+	unzip -p $(FONTS)/NotoSerif.zip NotoSerif-Bold.ttf > $(FONTS)/NotoSerif-Bold.ttf
+	unzip -p $(FONTS)/NotoSerif.zip NotoSerif-Italic.ttf > $(FONTS)/NotoSerif-Italic.ttf
+	unzip -p $(FONTS)/NotoSerif.zip NotoSerif-BoldItalic.ttf > $(FONTS)/NotoSerif-BoldItalic.ttf
+	rm $(FONTS)/NotoSerif.zip
+	wget -q -O $(FONTS)/NotoSansMono.zip https://fonts.google.com/download?family=Noto%20Sans%20Mono
+	unzip -p $(FONTS)/NotoSansMono.zip static/NotoSansMono/NotoSansMono-Regular.ttf > $(FONTS)/NotoSansMono-Regular.ttf
+	unzip -p $(FONTS)/NotoSansMono.zip static/NotoSansMono/NotoSansMono-Bold.ttf > $(FONTS)/NotoSansMono-Bold.ttf
+	rm $(FONTS)/NotoSansMono.zip
+	cp -r "$(FONTS)/." "$(WASM)/usr/share/fonts"
+	cp fonts.conf "$(WASM)/etc/fonts/local.conf"
+
+clean-fonts:
+	rm -rf "$(FONTS)" "$(WASM)/usr/share/fonts" "$(WASM)/etc/fonts/local.conf"
 
 .PHONY: clean
 clean:

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -21,7 +21,7 @@ CAIRO_TARBALL = $(DOWNLOAD)/cairo-$(CAIRO_VERSION).tar.xz
 CAIRO_URL = https://cairographics.org/releases/cairo-${CAIRO_VERSION}.tar.xz
 CAIRO_WASM_LIB = $(WASM)/lib/libcairo.a
 
-FC_VERSION = 2.13.92
+FC_VERSION = 2.12.5
 FC_TARBALL = $(DOWNLOAD)/fontconfig-$(FC_VERSION).tar.gz
 FC_URL = https://www.freedesktop.org/software/fontconfig/release/fontconfig-$(FC_VERSION).tar.gz
 FC_WASM_LIB = $(WASM)/lib/libfontconfig.a
@@ -61,7 +61,14 @@ WASM_LIBS += $(PCRE_WASM_LIB)
 WASM_LIBS += $(PIXMAN_WASM_LIB)
 WASM_LIBS += $(XZ_WASM_LIB)
 
+
+export EM_PKG_CONFIG_PATH = $(WASM)/lib/pkgconfig
+
 all: $(WASM_LIBS) $(WASM)/usr/share/fonts
+
+$(EM_PKG_CONFIG_PATH)/%.pc: %.pc
+	mkdir -p $(EM_PKG_CONFIG_PATH)
+	cp "$<" "$@"
 
 .PHONY: cairo
 cairo: $(CAIRO_WASM_LIB)
@@ -72,17 +79,13 @@ $(CAIRO_TARBALL):
 
 $(CAIRO_WASM_LIB): $(CAIRO_TARBALL) $(PIXMAN_WASM_LIB) $(FC_WASM_LIB)
 	rm -rf $(BUILD)/cairo-$(CAIRO_VERSION)
+	mkdir -p $(BUILD)/cairo-$(CAIRO_VERSION)/build
 	tar -C $(BUILD) -xf $(CAIRO_TARBALL)
 	cp -r "$(WEBR_ROOT)/patches/cairo-$(CAIRO_VERSION)/." \
 	  "$(BUILD)/cairo-$(CAIRO_VERSION)/patches"
-	cd "$(BUILD)/cairo-$(CAIRO_VERSION)" && quilt push -a
-	mkdir -p $(BUILD)/cairo-$(CAIRO_VERSION)/build
-	cd $(BUILD)/cairo-$(CAIRO_VERSION)/build && \
+	cd $(BUILD)/cairo-$(CAIRO_VERSION)/build && quilt push -a && \
 	  CFLAGS="$(WASM_CFLAGS) -DCAIRO_NO_MUTEX=1" \
 	  LDFLAGS="-sUSE_FREETYPE=1" \
-	  FREETYPE_CFLAGS="-sUSE_FREETYPE=1" \
-	  FREETYPE_LIBS="-sUSE_FREETYPE=1" \
-	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
 	  emconfigure ../configure \
 	    ax_cv_c_float_words_bigendian=no \
 	    --enable-shared=no \
@@ -92,10 +95,6 @@ $(CAIRO_WASM_LIB): $(CAIRO_TARBALL) $(PIXMAN_WASM_LIB) $(FC_WASM_LIB)
 	    --enable-fc=yes \
 	    --prefix=$(WASM) && \
 	  emmake make install
-	sed -i.bak -e 's/freetype2 >= [0-9]*\.[0-9]*\.[0-9]*//g' \
-		-e 's/-lz//2' $(WASM)/lib/pkgconfig/cairo.pc
-	sed -i.bak -e 's/freetype2 >= [0-9]*\.[0-9]*\.[0-9]*//g' $(WASM)/lib/pkgconfig/cairo-ft.pc
-	touch $@
 
 .PHONY: fontconfig
 fontconfig: $(FC_WASM_LIB)
@@ -104,31 +103,20 @@ $(FC_TARBALL):
 	mkdir -p $(DOWNLOAD)
 	wget -q -O $@ $(FC_URL)
 
-$(FC_WASM_LIB): $(FC_TARBALL) $(LIBXML2_WASM_LIB)
-	mkdir -p $(BUILD)
-	tar -C $(BUILD) -xf $(FC_TARBALL)
+$(FC_WASM_LIB): $(FC_TARBALL) $(LIBXML2_WASM_LIB) $(EM_PKG_CONFIG_PATH)/freetype2.pc
 	mkdir -p $(BUILD)/fontconfig-$(FC_VERSION)/build
-	sed -i.bak 's/ax_pthread_ok=yes/ax_pthread_ok=no/g' \
-	  $(BUILD)/fontconfig-$(FC_VERSION)/configure
-	sed -i.bak 's/RUN_FC_CACHE_TEST =.*/RUN_FC_CACHE_TEST = false/g' \
-	  $(BUILD)/fontconfig-$(FC_VERSION)/Makefile.in
+	tar -C $(BUILD) -xf $(FC_TARBALL) --exclude=fcobjshash.h
 	cd $(BUILD)/fontconfig-$(FC_VERSION)/build && \
 	  CFLAGS="$(WASM_CFLAGS)" \
-	  FREETYPE_CFLAGS="-sUSE_FREETYPE=1" \
-	  FREETYPE_LIBS="-sUSE_FREETYPE=1" \
 	  LDFLAGS="-sUSE_FREETYPE=1" \
-	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
+	  PTHREAD_CFLAGS=" " \
 	  emconfigure ../configure \
+	    ac_cv_func_fstatfs=no \
 	    --enable-shared=no \
 	    --enable-static=yes \
 	    --enable-libxml2 \
-	    --prefix=$(WASM)
-	sed -i.bak 's/#define HAVE_FSTATFS 1/#undef HAVE_FSTATFS/' \
-	  $(BUILD)/fontconfig-$(FC_VERSION)/build/config.h
-	cd $(BUILD)/fontconfig-$(FC_VERSION)/build && \
-	  emmake make install
-	sed -i.bak 's/Requires:.*/Requires:/' $(WASM)/lib/pkgconfig/fontconfig.pc
-	touch $@
+	    --prefix=$(WASM) && \
+	  emmake make RUN_FC_CACHE_TEST=false install
 
 .PHONY: libpng
 libpng: $(LIBPNG_WASM_LIB)
@@ -137,18 +125,16 @@ $(LIBPNG_TARBALL):
 	mkdir -p $(DOWNLOAD)
 	wget $(LIBPNG_URL) -O $@
 
-$(LIBPNG_WASM_LIB): $(LIBPNG_TARBALL)
-	mkdir -p $(BUILD)
+$(LIBPNG_WASM_LIB): $(LIBPNG_TARBALL) $(EM_PKG_CONFIG_PATH)/zlib.pc
+	mkdir -p $(BUILD)/libpng-$(LIBPNG_VERSION)/build
 	tar -C $(BUILD) -xf $(LIBPNG_TARBALL)
-	cd $(BUILD)/libpng-$(LIBPNG_VERSION) && \
-	  mkdir -p build && \
-	  cd build && \
-	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
+	cd $(BUILD)/libpng-$(LIBPNG_VERSION)/build && \
+	  CFLAGS="$(WASM_CFLAGS)" \
+	  emconfigure ../configure \
 	    --enable-shared=no \
 	    --enable-static=yes \
 	    --prefix=$(WASM) && \
 	  emmake make install
-	touch $@
 
 .PHONY: libxml2
 libxml2: $(LIBXML2_WASM_LIB)
@@ -157,13 +143,11 @@ $(LIBXML2_TARBALL):
 	mkdir -p $(DOWNLOAD)
 	wget -q -O $@ $(LIBXML2_URL)
 
-$(LIBXML2_WASM_LIB): $(LIBXML2_TARBALL) $(ZLIB_WASM_LIB) $(XZ_WASM_LIB)
-	mkdir -p $(BUILD)
-	tar -C $(BUILD) -xf $(LIBXML2_TARBALL)
+$(LIBXML2_WASM_LIB): $(LIBXML2_TARBALL) $(XZ_WASM_LIB)
 	mkdir -p $(BUILD)/libxml2-$(LIBXML2_VERSION)/build
+	tar -C $(BUILD) -xf $(LIBXML2_TARBALL)
 	cd $(BUILD)/libxml2-$(LIBXML2_VERSION)/build && \
 	  CFLAGS="$(WASM_CFLAGS)" \
-	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
 	  emconfigure ../configure \
 	    --enable-shared=no \
 	    --enable-static=yes \
@@ -171,7 +155,6 @@ $(LIBXML2_WASM_LIB): $(LIBXML2_TARBALL) $(ZLIB_WASM_LIB) $(XZ_WASM_LIB)
 	    --without-threads \
 	    --prefix=$(WASM) && \
 	  emmake make install
-	touch $@
 
 .PHONY: pcre2
 pcre2: $(PCRE_WASM_LIB)
@@ -181,16 +164,15 @@ $(PCRE_TARBALL):
 	wget -q -O $@ $(PCRE_URL)
 
 $(PCRE_WASM_LIB): $(PCRE_TARBALL)
-	mkdir -p $(BUILD)
-	tar -C $(BUILD) -xf $(PCRE_TARBALL)
 	mkdir -p $(BUILD)/pcre2-$(PCRE_VERSION)/build
+	tar -C $(BUILD) -xf $(PCRE_TARBALL)
 	cd $(BUILD)/pcre2-$(PCRE_VERSION)/build && \
-	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
+	  CFLAGS="$(WASM_CFLAGS)" \
+	  emconfigure ../configure \
 	    --enable-shared=no \
 	    --enable-static=yes \
 	    --prefix=$(WASM) && \
 	  emmake make install
-	touch $@
 
 .PHONY: pixman
 pixman: $(PIXMAN_WASM_LIB)
@@ -200,13 +182,12 @@ $(PIXMAN_TARBALL):
 	wget -q -O $@ $(PIXMAN_URL)
 
 $(PIXMAN_WASM_LIB): $(PIXMAN_TARBALL) $(LIBPNG_WASM_LIB)
-	tar -C $(BUILD) -xf $(PIXMAN_TARBALL)
 	mkdir -p $(BUILD)/pixman-$(PIXMAN_VERSION)/build
+	tar -C $(BUILD) -xf $(PIXMAN_TARBALL)
 	sed -i.bak 's/support_for_pthreads=yes/support_for_pthreads=no/g' \
 	  $(BUILD)/pixman-$(PIXMAN_VERSION)/configure
 	cd $(BUILD)/pixman-$(PIXMAN_VERSION)/build && \
 	  CFLAGS="$(WASM_CFLAGS)" \
-	  EM_PKG_CONFIG_PATH="$(WASM)/lib/pkgconfig" \
 	  emconfigure ../configure \
 	    --enable-shared=no \
 	    --enable-static=yes \
@@ -221,18 +202,16 @@ $(XZ_TARBALL):
 	wget $(XZ_URL) -O $@
 
 $(XZ_WASM_LIB): $(XZ_TARBALL)
-	mkdir -p $(BUILD)
+	mkdir -p $(BUILD)/xz-$(XZ_VERSION)/build
 	tar -C $(BUILD) -xf $(XZ_TARBALL)
-	cd $(BUILD)/xz-$(XZ_VERSION) && \
-	  mkdir -p build && \
-	  cd build && \
-	  CFLAGS="$(WASM_CFLAGS)" emconfigure ../configure \
+	cd $(BUILD)/xz-$(XZ_VERSION)/build && \
+	  CFLAGS="$(WASM_CFLAGS)" \
+	  emconfigure ../configure \
 	    --enable-shared=no \
 	    --enable-static=yes \
 	    --enable-threads=no \
 	    --prefix=$(WASM) && \
 	  emmake make install
-	touch $@
 
 .PHONY: fonts
 fonts: $(WASM)/usr/share/fonts

--- a/libs/fonts.conf
+++ b/libs/fonts.conf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+    <alias>
+        <family>sans-serif</family>
+        <prefer>
+            <family>Noto Sans</family>
+        </prefer>
+    </alias>
+    <alias>
+        <family>serif</family>
+        <prefer>
+            <family>Noto Serif</family>
+        </prefer>
+    </alias>
+    <alias>
+        <family>monospace</family>
+        <prefer>
+            <family>Noto Sans Mono</family>
+        </prefer>
+    </alias>
+</fontconfig>

--- a/libs/freetype2.pc
+++ b/libs/freetype2.pc
@@ -1,0 +1,5 @@
+Name: freetype
+Description: Emscripten ports version of freetype library
+Version: 18.0.12
+Cflags: -sUSE_FREETYPE=1
+Libs: -sUSE_FREETYPE=1

--- a/libs/zlib.pc
+++ b/libs/zlib.pc
@@ -1,0 +1,5 @@
+Name: zlib
+Description: Emscripten ports version of zlib library
+Version: 1.2.8
+Cflags: -sUSE_ZLIB=1
+Libs: -sUSE_ZLIB=1

--- a/patches/R-4.1.3/emscripten-makefiles.diff
+++ b/patches/R-4.1.3/emscripten-makefiles.diff
@@ -20,12 +20,13 @@ Index: R-4.1.3/src/main/Makefile.in
 ===================================================================
 --- R-4.1.3.orig/src/main/Makefile.in
 +++ R-4.1.3/src/main/Makefile.in
-@@ -147,6 +147,39 @@ $(R_binary): $(R_bin_OBJECTS) $(R_bin_DEPENDENCIES)
+@@ -147,6 +147,41 @@ $(R_binary): $(R_bin_OBJECTS) $(R_bin_DEPENDENCIES)
  $(R_binary): $(R_bin_OBJECTS) $(R_bin_DEPENDENCIES)
  	$(MAIN_LINK) -o $@ $(R_bin_OBJECTS) $(R_bin_LDADD)
  
 +MAIN_WEBR_LDADD  = --use-preload-plugins
 +MAIN_WEBR_LDADD += --preload-file "$(prefix)/tmp/lib@/usr/lib"
++MAIN_WEBR_LDADD += --preload-file "$(prefix)/../etc@/etc"
 +
 +ifdef WEBR_REPO
 +MAIN_WEBR_LDADD += --preload-file "$(WEBR_REPO)@/repo"

--- a/patches/R-4.1.3/emscripten-makefiles.diff
+++ b/patches/R-4.1.3/emscripten-makefiles.diff
@@ -27,6 +27,7 @@ Index: R-4.1.3/src/main/Makefile.in
 +MAIN_WEBR_LDADD  = --use-preload-plugins
 +MAIN_WEBR_LDADD += --preload-file "$(prefix)/tmp/lib@/usr/lib"
 +MAIN_WEBR_LDADD += --preload-file "$(prefix)/../etc@/etc"
++MAIN_WEBR_LDADD += --preload-file "$(prefix)/../usr/share/fonts@/usr/share/fonts"
 +
 +ifdef WEBR_REPO
 +MAIN_WEBR_LDADD += --preload-file "$(WEBR_REPO)@/repo"

--- a/patches/R-4.1.3/fontconfig-typeof.diff
+++ b/patches/R-4.1.3/fontconfig-typeof.diff
@@ -1,0 +1,18 @@
+Index: R-4.1.3/src/library/grDevices/src/cairo/cairoFns.c
+===================================================================
+--- R-4.1.3.orig/src/library/grDevices/src/cairo/cairoFns.c
++++ R-4.1.3/src/library/grDevices/src/cairo/cairoFns.c
+@@ -1316,10 +1316,13 @@ PangoCairo_Text(double x, double y,
+    with freetype2/fontconfig (FT implies FC in Cairo).
+ */
+ 
++#undef TYPEOF
+ #include <cairo-ft.h>
+ #include <ft2build.h> // currently included by cairo-ft.h
+ #include FT_FREETYPE_H
+ #include <fontconfig/fontconfig.h>
++#undef TYPEOF
++#define TYPEOF(x)     ((x)->sxpinfo.type)
+ 
+ SEXP in_CairoFT(void) 
+ {

--- a/patches/R-4.1.3/series
+++ b/patches/R-4.1.3/series
@@ -19,3 +19,4 @@ fix-signrank-wilcox.diff
 emscripten-avoid-testing-issues.diff
 fix-dtptrs.diff
 flang-avoid-maxloc.diff
+fontconfig-typeof.diff

--- a/patches/cairo-1.14.12/null-surface.diff
+++ b/patches/cairo-1.14.12/null-surface.diff
@@ -1,0 +1,129 @@
+Index: cairo-1.14.12/src/cairo-analysis-surface.c
+===================================================================
+--- cairo-1.14.12.orig/src/cairo-analysis-surface.c
++++ cairo-1.14.12/src/cairo-analysis-surface.c
+@@ -830,56 +830,64 @@ static cairo_int_status_t
+ /* null surface type: a surface that does nothing (has no side effects, yay!) */
+ 
+ static cairo_int_status_t
+-_return_success (void)
++_return_success_paint (void *surface,
++		       cairo_operator_t op,
++		       const cairo_pattern_t *source,
++		       const cairo_clip_t *clip)
+ {
+     return CAIRO_STATUS_SUCCESS;
+ }
+ 
+-/* These typedefs are just to silence the compiler... */
+-typedef cairo_int_status_t
+-(*_paint_func)			(void			*surface,
+-			         cairo_operator_t	 op,
+-				 const cairo_pattern_t	*source,
+-				 const cairo_clip_t		*clip);
++static cairo_int_status_t
++_return_success_mask (void *surface,
++		      cairo_operator_t op,
++		      const cairo_pattern_t *source,
++		      const cairo_pattern_t *mask,
++		      const cairo_clip_t *clip)
++{
++    return CAIRO_STATUS_SUCCESS;
++}
+ 
+-typedef cairo_int_status_t
+-(*_mask_func)			(void			*surface,
+-			         cairo_operator_t	 op,
+-				 const cairo_pattern_t	*source,
+-				 const cairo_pattern_t	*mask,
+-				 const cairo_clip_t		*clip);
++static cairo_int_status_t
++_return_success_stroke (void *surface,
++			cairo_operator_t op,
++			const cairo_pattern_t *source,
++			const cairo_path_fixed_t *path,
++			const cairo_stroke_style_t *style,
++			const cairo_matrix_t *ctm,
++			const cairo_matrix_t *ctm_inverse,
++			double tolerance,
++			cairo_antialias_t antialias,
++			const cairo_clip_t *clip)
++{
++    return CAIRO_STATUS_SUCCESS;
++}
+ 
+-typedef cairo_int_status_t
+-(*_stroke_func)			(void			*surface,
+-			         cairo_operator_t	 op,
+-				 const cairo_pattern_t	*source,
+-				 const cairo_path_fixed_t	*path,
+-				 const cairo_stroke_style_t	*style,
+-				 const cairo_matrix_t		*ctm,
+-				 const cairo_matrix_t		*ctm_inverse,
+-				 double			 tolerance,
+-				 cairo_antialias_t	 antialias,
+-				 const cairo_clip_t		*clip);
++static cairo_int_status_t
++_return_success_fill (void *surface,
++		      cairo_operator_t op,
++		      const cairo_pattern_t *source,
++		      const cairo_path_fixed_t *path,
++		      cairo_fill_rule_t fill_rule,
++		      double tolerance,
++		      cairo_antialias_t antialias,
++		      const cairo_clip_t *clip)
++{
++    return CAIRO_STATUS_SUCCESS;
++}
+ 
+-typedef cairo_int_status_t
+-(*_fill_func)			(void			*surface,
+-			         cairo_operator_t	 op,
+-				 const cairo_pattern_t	*source,
+-				 const cairo_path_fixed_t	*path,
+-				 cairo_fill_rule_t	 fill_rule,
+-				 double			 tolerance,
+-				 cairo_antialias_t	 antialias,
+-				 const cairo_clip_t		*clip);
++static cairo_int_status_t
++_return_success_show_glyphs (void *surface,
++			     cairo_operator_t op,
++			     const cairo_pattern_t *source,
++			     cairo_glyph_t *glyphs,
++			     int num_glyphs,
++			     cairo_scaled_font_t *scaled_font,
++			     const cairo_clip_t *clip)
++{
++    return CAIRO_STATUS_SUCCESS;
++}
+ 
+-typedef cairo_int_status_t
+-(*_show_glyphs_func)		(void			*surface,
+-			         cairo_operator_t	 op,
+-				 const cairo_pattern_t	*source,
+-				 cairo_glyph_t		*glyphs,
+-				 int			 num_glyphs,
+-				 cairo_scaled_font_t	*scaled_font,
+-				 const cairo_clip_t		*clip);
+-
+ static const cairo_surface_backend_t cairo_null_surface_backend = {
+     CAIRO_INTERNAL_SURFACE_TYPE_NULL,
+     NULL, /* finish */
+@@ -905,12 +913,12 @@ static const cairo_surface_backend_t cairo_null_surfac
+     NULL, /* flush */
+     NULL, /* mark_dirty_rectangle */
+ 
+-    (_paint_func) _return_success,	    /* paint */
+-    (_mask_func) _return_success,	    /* mask */
+-    (_stroke_func) _return_success,	    /* stroke */
+-    (_fill_func) _return_success,	    /* fill */
++    _return_success_paint,	    /* paint */
++    _return_success_mask,	    /* mask */
++    _return_success_stroke,	    /* stroke */
++    _return_success_fill,	    /* fill */
+     NULL, /* fill_stroke */
+-    (_show_glyphs_func) _return_success,    /* show_glyphs */
++    _return_success_show_glyphs,    /* show_glyphs */
+     NULL, /* has_show_text_glyphs */
+     NULL  /* show_text_glyphs */
+ };

--- a/patches/cairo-1.14.12/path-fill.diff
+++ b/patches/cairo-1.14.12/path-fill.diff
@@ -1,0 +1,28 @@
+Index: cairo-1.14.12/src/cairo-path-fill.c
+===================================================================
+--- cairo-1.14.12.orig/src/cairo-path-fill.c
++++ cairo-1.14.12/src/cairo-path-fill.c
+@@ -70,6 +70,14 @@ static cairo_status_t
+ }
+ 
+ static cairo_status_t
++_cairo_filler_line_to_spline (void *closure,
++			      const cairo_point_t *point,
++			      const cairo_slope_t *tangent)
++{
++    return _cairo_filler_line_to (closure, point);
++}
++
++static cairo_status_t
+ _cairo_filler_close (void *closure)
+ {
+     cairo_filler_t *filler = closure;
+@@ -113,7 +121,7 @@ _cairo_filler_curve_to (void		*closure,
+     }
+ 
+     if (! _cairo_spline_init (&spline,
+-			      (cairo_spline_add_point_func_t)_cairo_filler_line_to, filler,
++			      _cairo_filler_line_to_spline, filler,
+ 			      &filler->current_point, p1, p2, p3))
+     {
+ 	return _cairo_filler_line_to (closure, p3);

--- a/patches/cairo-1.14.12/series
+++ b/patches/cairo-1.14.12/series
@@ -1,0 +1,2 @@
+null-surface.diff
+path-fill.diff

--- a/src/console/console.ts
+++ b/src/console/console.ts
@@ -67,6 +67,7 @@ export class Console {
     options: WebROptions = {
       REnv: {
         R_HOME: '/usr/lib/R',
+        FONTCONFIG_PATH: '/etc/fonts',
         R_ENABLE_JIT: '0',
         R_DEFAULT_DEVICE: 'canvas',
       },

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -66,6 +66,7 @@ const webR = new WebR({
   RArgs: [],
   REnv: {
     R_HOME: '/usr/lib/R',
+    FONTCONFIG_PATH: '/etc/fonts',
     R_ENABLE_JIT: '0',
     R_DEFAULT_DEVICE: 'canvas',
     COLORTERM: 'truecolor',

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -141,6 +141,7 @@ export interface WebROptions {
 }
 
 const defaultEnv = {
+  FONTCONFIG_PATH: '/etc/fonts',
   R_HOME: '/usr/lib/R',
   R_ENABLE_JIT: '0',
 };


### PR DESCRIPTION
This PR tweaks `/libs/Makefile` so that it builds Cairo and its prerequisites for Wasm, which are then statically linked as part of the R Wasm build. This allows us to use the default bitmap graphics devices (`png()` etc) since they can use Cario for rendering graphics.

This is a prerequisite for Shiny compatibility. We could limit ourselves to SVG, but support in Shiny requires a non-ideal wrapper (issue https://github.com/rstudio/shiny/issues/2057), so existing apps would need to be modified.

Even without thinking about Shiny, I think this is a good thing to have. With this change, we can consider removing the patch that adds the HTML `canvas` graphics device, or at least moving it out of base R and into the webr support package. Instead, we could generate bitmaps fully in the worker thread and transfer them to the main thread. That has the potential of making plot capture with tools like `captureR()` much easier (no need to wait for `OffscreenCanvas` support in Safari, for example).

The downside is that plots rendered this way require TrueType fonts on the virtual file system. At the moment a suite of ~Roboto~ Noto fonts are downloaded from Google Fonts at build time and bundled with webR. There's a balance to be made here between Unicode coverage/font quality and file size.

## Download size comparison

| File | Without Cairo (v0.1.1) | Without Cairo (dev) | With Cairo & Noto fonts
| ------------- | ------------- | --- |---|
| `R.bin.data`  | 28.6MB  | 12.8MB | 17.0MB
| `R.bin.wasm`  | 12.7MB  | 5.5MB |  6.1MB

TODO:
- [x] Consider the choices in `fonts.conf` - do we need to support more Unicode glyphs? Should we have fallbacks?
- [x] Consider the consequences of building and including several more wasm libraries as part of webR.
- [x] Benchmark changes in initial webR download size with this change.
- [x] ~~Take a look at the `sed` patches in `libs/Makefile`~~ This has now been tidied up a lot.
- [x] Think about how this fits in with the lazy network filesystem proposal.
- [x] Check extra system prerequisites for building new libs - add to docker and `README.md`.