### PR TITLE
Add R proxy object type predicate functions for TypeScript

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Issue an output message of type `'closed'` when the webR communication channel closes.
 * Build Cairo graphics library and its prerequisites for Wasm as part of the webR build process. This allows the default Cairo-based graphics devices in R, such as `png()`, `bmp()` and `svg()`, to work in webR.
 * Update webR's version of R to 4.3.0.
+* Include additional type predicate functions for subclasses of `RObject`, such as `isRDouble()`. These can be used by TypeScript applications to narrow the typing of an `RObject`.
 
 # webR 0.1.1
 

--- a/src/webR/robj-main.ts
+++ b/src/webR/robj-main.ts
@@ -47,6 +47,126 @@ export function isRObject(value: any): value is RObject {
 }
 
 /**
+ * Test for an RNull instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RNull.
+ */
+export function isRNull(value: any): value is RNull {
+  return isRObject(value) && value._payload.obj.type === 'null';
+}
+
+/**
+ * Test for an RSymbol instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RSymbol.
+ */
+export function isRSymbol(value: any): value is RSymbol {
+  return isRObject(value) && value._payload.obj.type === 'symbol';
+}
+
+/**
+ * Test for an RPairlist instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RPairlist.
+ */
+export function isRPairlist(value: any): value is RPairlist {
+  return isRObject(value) && value._payload.obj.type === 'pairlist';
+}
+
+/**
+ * Test for an REnvironment instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an REnvironment.
+ */
+export function isREnvironment(value: any): value is REnvironment {
+  return isRObject(value) && value._payload.obj.type === 'environment';
+}
+
+/**
+ * Test for an RLogical instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RLogical.
+ */
+export function isRLogical(value: any): value is RLogical {
+  return isRObject(value) && value._payload.obj.type === 'logical';
+}
+
+/**
+ * Test for an RInteger instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RInteger.
+ */
+export function isRInteger(value: any): value is RInteger {
+  return isRObject(value) && value._payload.obj.type === 'integer';
+}
+
+/**
+ * Test for an RDouble instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RDouble.
+ */
+export function isRDouble(value: any): value is RDouble {
+  return isRObject(value) && value._payload.obj.type === 'double';
+}
+
+/**
+ * Test for an RComplex instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RComplex.
+ */
+export function isRComplex(value: any): value is RComplex {
+  return isRObject(value) && value._payload.obj.type === 'complex';
+}
+
+/**
+ * Test for an RCharacter instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RCharacter.
+ */
+export function isRCharacter(value: any): value is RCharacter {
+  return isRObject(value) && value._payload.obj.type === 'character';
+}
+
+/**
+ * Test for an RList instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RList.
+ */
+export function isRList(value: any): value is RList {
+  return isRObject(value) && value._payload.obj.type === 'list';
+}
+
+/**
+ * Test for an RRaw instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RRaw.
+ */
+export function isRRaw(value: any): value is RRaw {
+  return isRObject(value) && value._payload.obj.type === 'raw';
+}
+
+/**
+ * Test for an RCall instance
+ *
+ * @param {any} value The object to test.
+ * @returns {boolean} True if the object is an instance of an RCall.
+ */
+export function isRCall(value: any): value is RCall {
+  return isRObject(value) && value._payload.obj.type === 'call';
+}
+
+/**
  * Test for an RFunction instance
  *
  * @param {any} value The object to test.


### PR DESCRIPTION
Up until now, we have been asserting the type of objects returned from `webR.evalR` using the TypeScript `as` keyword,

``` javascript
const foo = await webR.evalR('123') as RDouble;
```

This works OK when we know the returned object type at compile time.

For unknown R objects, the type must be detected at runtime. This can be done reasonably well with `RObject.type()` and `as`, but the type assertions do not feel very elegant,

``` javascript
const foo = await webR.evalR('some_unknown_var');
const fooType = await foo.type();

if (fooType === 'double') {
  const bar = foo as RDouble;
  console.log(bar.toNumber());
} else if (fooType === 'character') {
  const bar = foo as RCharacter;
  console.log(bar.toString());
}
```

This PR adds and exports more type predicate functions in `robj-main`. This simplifies things, as TypeScript can use them to perform type narrowing automatically. This removes the need to use the `as` keyword to assert the type and simplifies the code,

``` javascript
const obj = await webR.evalR('some_unknown_var');

if (isRDouble(obj)){
  console.log(obj.toNumber());
} else if (isRCharacter(obj)) {
  console.log(obj.toString());
}
```