### PR TITLE
Enable screenReaderMode for xterm.js in REPL app

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 # webR 0.1.1
 
+* Improve accessibility of xterm.js in the webR REPL app by enabling `screenReaderMode`.
+
 ## Breaking changes
  * Rename the properties of `WebROptions` so that they are all in camelCase, consistent with the rest of the webR TypeScript source. We have made the decision to release the above breaking change quickly while there are still a relatively low number of affected users.
 

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -11,6 +11,7 @@ const term = new Terminal({
     background: '#191919',
     foreground: '#F0F0F0',
   },
+  screenReaderMode: true,
 });
 const fitAddon = new FitAddon();
 const readline = new Readline();


### PR DESCRIPTION
The xterm.js documentation claims that turning on this setting will expose supporting elements in the DOM to support NVDA on Windows and VoiceOver on macOS.

This should make the webR REPL app accessible to screen readers, fixing #181.