### PR TITLE
Issue a 'closed' message when the webR communication channel closes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # webR (development version)
 
 * Improve accessibility of xterm.js in the webR REPL app by enabling `screenReaderMode`.
+* Issue an output message of type `'closed'` when the webR communication channel closes.
 
 # webR 0.1.1
 

--- a/src/console/console.ts
+++ b/src/console/console.ts
@@ -148,7 +148,8 @@ export class Console {
    * This loop waits for output from webR and dispatches callbacks based on the
    * message recieved.
    *
-   * The promise returned by this asynchronous function never resolves.
+   * The promise returned by this asynchronous function resolves only once the
+   * webR communication channel has closed.
    */
   async #run() {
     for (;;) {
@@ -166,6 +167,8 @@ export class Console {
         case 'canvasExec':
           this.#canvasExec(output.data as string);
           break;
+        case 'closed':
+          return;
         default:
           console.warn(`Unhandled output type for webR Console: ${output.type}.`);
       }

--- a/src/docs/communication.qmd
+++ b/src/docs/communication.qmd
@@ -119,7 +119,7 @@ A convenience function [`WebR.installPackages()`](api/js/classes/WebR.WebR.md#in
 
 A long running R computation can be interrupted by sending an interruption request message using the [`WebR.interrupt()`](api/js/classes/WebR.WebR.md#interrupt) method.
 
-### Ouput messages
+### Output messages
 
 #### Standard output streams
 
@@ -136,6 +136,16 @@ Messages of type `prompt` are sent to the output queue when R has given a prompt
 ``` javascript
 { type: 'prompt', data: string }
 ```
+
+#### Closed
+
+A message of type `closed` is issued when the webR worker thread and communication channel have been terminated using [`WebR.close()`](api/js/classes/WebR.WebR.md#close). This message indicates that the webR instance should no longer be used and no further messages will be issued. The `data` property is undefined for this type of message.
+
+``` javascript
+{ type: 'closed' }
+```
+
+This type of message can be a useful signal to break out of an otherwise infinite asynchronous loop of reading webR output messages.
 
 #### Plotting with the webR HTML canvas
 

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -182,6 +182,8 @@ const webR = new WebR({
            document.getElementById('plot-canvas').getContext('2d').${output.data as string}
          `)();
         break;
+      case 'closed':
+        throw new Error('The webR communication channel has been closed');
       default:
         console.error(`Unimplemented output type: ${output.type}`);
         console.error(output.data);

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -658,6 +658,32 @@ test('Invoke a wasm function after a delay', async () => {
   expect((await webR.read()).data).toBe('Hello, World!');
 });
 
+test('Close webR communication channel', async () => {
+  const tempR = new WebR({ baseUrl: '../dist/' });
+  await tempR.init();
+
+  // Promise resolves when the webR communication channel closes
+  const closedPromise = new Promise((resolve) => {
+    (async () => {
+      for (;;) {
+        const output = await tempR.read();
+        if (output.type === 'closed') {
+          break;
+        }
+      }
+      resolve(true);
+    })();
+  });
+
+  // Generate some activity
+  tempR.writeConsole('foo <- 123');
+  tempR.writeConsole('print(foo)');
+
+  // Close the channel
+  tempR.close();
+  await expect(closedPromise).resolves.toEqual(true);
+});
+
 beforeEach(() => {
   jest.restoreAllMocks();
 });

--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -35,7 +35,10 @@ export class ServiceWorkerChannelMain extends ChannelMain {
     super();
     const initWorker = (worker: Worker) => {
       this.#handleEventsFromWorker(worker);
-      this.close = () => worker.terminate();
+      this.close = () => {
+        worker.terminate();
+        this.putClosedMessage();
+      };
       this.#registerServiceWorker(`${config.serviceWorkerUrl}webr-serviceworker.js`).then(
         (clientId) => {
           const msg = {

--- a/src/webR/chan/channel-shared.ts
+++ b/src/webR/chan/channel-shared.ts
@@ -25,7 +25,10 @@ export class SharedBufferChannelMain extends ChannelMain {
     super();
     const initWorker = (worker: Worker) => {
       this.#handleEventsFromWorker(worker);
-      this.close = () => worker.terminate();
+      this.close = () => {
+        worker.terminate();
+        this.putClosedMessage();
+      };
       const msg = {
         type: 'init',
         data: { config, channelType: ChannelType.SharedArrayBuffer },

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -69,6 +69,10 @@ export abstract class ChannelMain {
     return promise as Promise<WebRPayload>;
   }
 
+  protected putClosedMessage(): void {
+    this.outputQueue.put({ type: 'closed' });
+  }
+
   protected resolveResponse(msg: Response) {
     const uuid = msg.data.uuid;
     const handles = this.#parked.get(uuid);


### PR DESCRIPTION
As I briefly mentioned as part of my response to #185, an output message when the webR communication channel closes could be useful when multiple webR instances are initialised and closed over the lifetime of a long-running app.

For example, the message can be used to indicate when to break out of an otherwise infinite async loop that has been set up to wait for and read messages from the output queue.