### PR TITLE
Update install.R - omitted warning

### DIFF
--- a/packages/webr/R/install.R
+++ b/packages/webr/R/install.R
@@ -29,7 +29,7 @@ install <- function(packages, repos = NULL, lib = NULL) {
     }
 
     if (!pkg %in% rownames(info)) {
-      warning(cat("Requested package", pkg, "not found in webR binary repo.\n"))
+      warning(paste("Requested package", pkg, "not found in webR binary repo."))
       next
     }
 

--- a/packages/webr/R/install.R
+++ b/packages/webr/R/install.R
@@ -29,7 +29,17 @@ install <- function(packages, repos = NULL, lib = NULL) {
     }
 
     if (!pkg %in% info) {
-      warning(cat("Requested package", pkg, "not found in webR binary repo.\n"))
+      warning(
+        sprintf(
+          paste0(
+            "Requested package %s not found in webR binary repo.\n",
+            "Please run `rownames(available.packages(repos = '%s'))` to get available packages\n"
+          ), 
+          pkg, 
+          repos
+        )
+      )
+
       next
     }
 

--- a/packages/webr/R/install.R
+++ b/packages/webr/R/install.R
@@ -29,17 +29,7 @@ install <- function(packages, repos = NULL, lib = NULL) {
     }
 
     if (!pkg %in% info) {
-      warning(
-        sprintf(
-          paste0(
-            "Requested package %s not found in webR binary repo.\n",
-            "Please run `rownames(available.packages(repos = '%s'))` to get available packages\n"
-          ), 
-          pkg, 
-          repos
-        )
-      )
-
+      warning(paste("Requested package", pkg, "not found in webR binary repo."))
       next
     }
 


### PR DESCRIPTION
The warning call is not used correctly because of the `cat` call inside it.
Please compare `warning(cat("Hello World\n"))` with `warning("Hello World\n")`.
Additionally, I expanded the warning message to be more helpful, and this update is optional.