### PR TITLE
Use msgpack to encode & decode data for channel transfer

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@r-wasm/webr",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.2-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@r-wasm/webr",
-      "version": "0.1.0-alpha.18",
+      "version": "0.1.2-dev",
       "license": "SEE LICENSE IN LICENCE.md",
       "dependencies": {
+        "@msgpack/msgpack": "^2.8.0",
         "@types/emscripten": "^1.39.6",
         "jquery": "^3.6.0",
         "jstree": "^3.3.12",
@@ -1187,6 +1188,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8442,6 +8451,11 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/src/package.json
+++ b/src/package.json
@@ -72,6 +72,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
+    "@msgpack/msgpack": "^2.8.0",
     "@types/emscripten": "^1.39.6",
     "jquery": "^3.6.0",
     "jstree": "^3.3.12",

--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -5,9 +5,8 @@ import {
   Response,
   Request,
   newResponse,
-  encodeData,
-  decodeData,
 } from './message';
+import { encode, decode } from '@msgpack/msgpack';
 import { Endpoint } from './task-common';
 import { ChannelMain, ChannelWorker } from './channel';
 import { ChannelType } from './channel-common';
@@ -249,8 +248,8 @@ export class ServiceWorkerChannelWorker implements ChannelWorker {
           clientId: this.#mainThreadId,
           uuid: request.data.uuid,
         };
-        xhr.send(encodeData(fetchReqBody));
-        return decodeData(new Uint8Array(xhr.response as ArrayBuffer)) as Response;
+        xhr.send(encode(fetchReqBody));
+        return decode(xhr.response as ArrayBuffer) as Response;
       } catch (e: any) {
         if (e instanceof DOMException && retryCount++ < 1000) {
           console.log('Service worker request failed - resending request');

--- a/src/webR/chan/message.ts
+++ b/src/webR/chan/message.ts
@@ -93,27 +93,3 @@ export function newSyncRequest(msg: Message, data: SyncRequestData): SyncRequest
     data: { msg, reqData: data },
   };
 }
-
-const encoder = new TextEncoder();
-const decoder = new TextDecoder('utf-8');
-
-/**
- * Encode data for transfering from worker thread to main thread.
- * @param {any} data The message data to be serialised and encoded.
- * @return {Uint8Array} The encoded data.
- * @internal
- * */
-export function encodeData(data: any): Uint8Array {
-  // TODO: Pass a `replacer` function
-  return encoder.encode(JSON.stringify(data));
-}
-
-/**
- * Decode data that has been transferred from worker thread to main thread.
- * @param {any} data The message data to be decoded.
- * @return {unknown} The data after decoding.
- * @internal
- * */
-export function decodeData(data: Uint8Array): unknown {
-  return JSON.parse(decoder.decode(data)) as unknown;
-}

--- a/src/webR/chan/serviceworker.ts
+++ b/src/webR/chan/serviceworker.ts
@@ -1,5 +1,5 @@
 import { promiseHandles } from '../utils';
-import { decodeData, encodeData } from './message';
+import { encode, decode } from '@msgpack/msgpack';
 import { ServiceWorkerHandlers } from './channel';
 
 declare let self: ServiceWorkerGlobalScope;
@@ -35,7 +35,7 @@ async function sendRequest(clientId: string, uuid: string): Promise<Response> {
 
   const response = await requests[uuid].promise;
   const headers = { 'Cross-Origin-Embedder-Policy': 'require-corp' };
-  return new Response(encodeData(response), { headers });
+  return new Response(encode(response), { headers });
 }
 
 export function handleFetch(event: FetchEvent) {
@@ -46,7 +46,7 @@ export function handleFetch(event: FetchEvent) {
   }
   const requestBody = event.request.arrayBuffer();
   const requestReponse = requestBody.then(async (body) => {
-    const data = decodeData(new Uint8Array(body)) as { clientId: string; uuid: string };
+    const data = decode(body) as { clientId: string; uuid: string };
     return await sendRequest(data.clientId, data.uuid);
   });
   event.waitUntil(requestReponse);

--- a/src/webR/chan/task-main.ts
+++ b/src/webR/chan/task-main.ts
@@ -3,7 +3,8 @@
 import { Endpoint, SZ_BUF_FITS_IDX, SZ_BUF_SIZE_IDX, generateUUID } from './task-common';
 
 import { sleep } from '../utils';
-import { SyncRequestData, encodeData } from './message';
+import { SyncRequestData } from './message';
+import { encode } from '@msgpack/msgpack';
 
 import { IN_NODE } from '../compat';
 import type { Worker as NodeWorker } from 'worker_threads';
@@ -28,7 +29,7 @@ export async function syncResponse(endpoint: Endpoint, data: SyncRequestData, re
     let { taskId, sizeBuffer, dataBuffer, signalBuffer } = data;
     // console.warn(msg);
 
-    const bytes = encodeData(response);
+    const bytes = encode(response);
     const fits = bytes.length <= dataBuffer.length;
 
     Atomics.store(sizeBuffer, SZ_BUF_SIZE_IDX, bytes.length);

--- a/src/webR/chan/task-worker.ts
+++ b/src/webR/chan/task-worker.ts
@@ -8,7 +8,8 @@ import {
   UUID_LENGTH,
 } from './task-common';
 
-import { newSyncRequest, Message, decodeData } from './message';
+import { newSyncRequest, Message } from './message';
+import { decode } from '@msgpack/msgpack';
 
 const decoder = new TextDecoder('utf-8');
 
@@ -99,7 +100,7 @@ export class SyncTask {
 
     const size = Atomics.load(sizeBuffer, SZ_BUF_SIZE_IDX);
     // console.log("===completing", taskId);
-    return decodeData(dataBuffer.slice(0, size));
+    return decode(dataBuffer.slice(0, size));
   }
 
   get result() {

--- a/src/webR/robj-worker.ts
+++ b/src/webR/robj-worker.ts
@@ -1105,7 +1105,7 @@ function toWebRData(jsObj: WebRData): WebRData;
 function toWebRData(jsObj: WebRData): WebRData {
   if (isWebRDataJs(jsObj)) {
     return jsObj;
-  } else if (Array.isArray(jsObj)) {
+  } else if (Array.isArray(jsObj) || ArrayBuffer.isView(jsObj)) {
     return { names: null, values: jsObj };
   } else if (jsObj && typeof jsObj === 'object' && !isComplex(jsObj)) {
     return {


### PR DESCRIPTION
The [@msgpack/msgpack](https://www.npmjs.com/package/@msgpack/msgpack/v/2.8.0) npm library is a JS implementation of the serialisation format described at https://msgpack.org. It is designed to be a fast and efficient binary serialisation scheme, and IMO is a better fit for the types of messages (i.e. containing possibly large raw data) that we send over the webR channels.

Using msgpack, rather than encoding messages with JSON, leads to a significant performance improvement when sending large messages. See, for example, [the benchmark given in #203](https://github.com/r-wasm/webr/issues/203#issuecomment-1531078857). In that test there is a greater than 10x speedup in transferring data from the main thread to the worker thread with this change.

---

Additionally, a minor change is made to `toWebRData` fixing an issue where `ArrayBuffer` is treated like an object rather than an array, generating a very large `names` array containing stringified indexes (e.g. `['1', '2', ..., '10485760']`). In my own quick benchmark, this fix takes the time for an `await webR.RRaw(object)` for a 10MB object down from around 10 seconds to 500 ms.