### PR TITLE
Merge `REnv` property of `WebROptions` with the default value, rather than replacing it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,22 @@
 # webR (development version)
 
+## New features
+
 * Improve accessibility of xterm.js in the webR REPL app by enabling `screenReaderMode`.
+
 * Issue an output message of type `'closed'` when the webR communication channel closes.
+
 * Build Cairo graphics library and its prerequisites for Wasm as part of the webR build process. This allows the default Cairo-based graphics devices in R, such as `png()`, `bmp()` and `svg()`, to work in webR.
+
+* Build Pango text layout library and its prerequisites for Wasm. This provides modern text rendering features and better support for internationalisation (e.g. font-fallback and RTL scripts) for the Cairo-based bitmap graphics devices.
+
 * Update webR's version of R to 4.3.0.
+
 * Include additional type predicate functions for subclasses of `RObject`, such as `isRDouble()`. These can be used by TypeScript applications to narrow the typing of an `RObject`.
+
+## Bug fixes
+
+* The `REnv` property of a user provided `WebROptions` is now merged with the default value, rather than replacing it. With this a user need not explicitly include the default `R_HOME` value when adding new environment variables.
 
 # webR 0.1.1
 

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -684,6 +684,27 @@ test('Close webR communication channel', async () => {
   await expect(closedPromise).resolves.toEqual(true);
 });
 
+test('Default and user provided REnv properties are merged', async () => {
+  const tempR = new WebR({
+    baseUrl: '../dist/',
+    REnv: {
+      FOO: 'bar',
+    }
+  });
+  await tempR.init();
+
+  // Confirm default REnv settings
+  const jit = await tempR.evalRString('Sys.getenv("R_ENABLE_JIT")');
+  const home = await tempR.evalRString('Sys.getenv("R_HOME")');
+  expect(jit).toEqual('0');
+  expect(home).toEqual('/usr/lib/R');
+
+  // Confirm a user REnv setting
+  const foo = await tempR.evalRString('Sys.getenv("FOO")');
+  expect(foo).toEqual('bar');
+  tempR.close();
+});
+
 beforeEach(() => {
   jest.restoreAllMocks();
 });

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -194,7 +194,14 @@ export class WebR {
   Shelter;
 
   constructor(options: WebROptions = {}) {
-    const config: Required<WebROptions> = Object.assign(defaultOptions, options);
+    const config: Required<WebROptions> = {
+      ...defaultOptions,
+      ...options,
+      REnv: {
+        ...defaultOptions.REnv,
+        ...options.REnv,
+      }
+    };
     this.#chan = newChannelMain(config);
 
     this.objs = {} as typeof this.objs;


### PR DESCRIPTION
Fixes #202.

Also includes an update to `NEWS.md` covering this PR and #216 (closed on GH but merged manually).