### PR TITLE
Use system message channel for logging to console in `evalR()`

### DIFF
--- a/src/tests/webR/webr-worker.test.ts
+++ b/src/tests/webR/webr-worker.test.ts
@@ -12,15 +12,19 @@ beforeAll(async () => {
 
 describe('Download and install binary webR packages', () => {
   test('Install packages via evalR', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation((...args) => {});
     await webR.evalR('webr::install("cli", repos="https://repo.r-wasm.org/")');
     const pkg = (await webR.evalR('"cli" %in% library(cli)')) as RLogical;
     expect(await pkg.toBoolean()).toEqual(true);
+    warnSpy.mockRestore();
   });
 
   test('Install packages via API', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation((...args) => {});
     await webR.installPackages(['MASS']);
     const pkg = (await webR.evalR('"MASS" %in% library(MASS)')) as RLogical;
     expect(await pkg.toBoolean()).toEqual(true);
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -255,6 +255,15 @@ export class WebR {
             msg.data.args
           );
           break;
+        case 'console.log':
+          console.log(msg.data);
+          break;
+        case 'console.warn':
+          console.warn(msg.data);
+          break;
+        case 'console.error':
+          console.error(msg.data);
+          break;
         default:
           throw new Error('Unknown system message type `' + msg.type + '`');
       }

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -601,20 +601,26 @@ function evalR(code: string, options: EvalROptions = {}): RObject {
       const outputType = out.get('type').toString();
       switch (outputType) {
         case 'stdout':
-          console.log(out.get('data').toString());
+          chan?.writeSystem({ type: 'console.log', data: out.get('data').toString() });
           break;
         case 'stderr':
-          console.warn(out.get('data').toString());
+          chan?.writeSystem({ type: 'console.warn', data: out.get('data').toString() });
           break;
         case 'message':
-          console.warn(out.pluck('data', 'message')?.toString() || '');
+          chan?.writeSystem({
+            type: 'console.warn',
+            data: out.pluck('data', 'message')?.toString() || '',
+          });
           break;
         case 'warning':
-          console.warn(`Warning message: \n${out.pluck('data', 'message')?.toString() || ''}`);
+          chan?.writeSystem({
+            type: 'console.warn',
+            data: `Warning message: \n${out.pluck('data', 'message')?.toString() || ''}`,
+          });
           break;
         default:
-          console.warn(`Output of type ${outputType}:`);
-          console.warn(out.get('data').toJs());
+          chan?.writeSystem({ type: 'console.warn', data: `Output of type ${outputType}:` });
+          chan?.writeSystem({ type: 'console.warn', data: out.get('data').toJs() });
           break;
       }
     }


### PR DESCRIPTION
At the time of writing, logging to console from Worker threads does not work in Node if the worker (or main) thread is blocking -- yielding to the event loop is required. See https://github.com/nodejs/node/issues/30491 for further info.

This PR tweaks `evalR()` so that rather than directly logging to console from the worker thread, messages are instead sent to the main thread over the existing side-channel for internal system messages (currently only used for scheduling timeouts for Wasm functions).

Three new system message types are added: `console.log`, `console.warn` and `console.error`, which simply pass the message data to the associated logging function running on the main thread, rather than the worker thread.

This avoids the node logging issue, and so fixes #210. It also has a nice side effect of simplifying some test code that previously relied on a hack to spy on console output when running under Node.