### PR TITLE
Fix lazy font downloading when plotting with Cairo graphics

### DIFF
--- a/libs/Makefile
+++ b/libs/Makefile
@@ -50,7 +50,7 @@ default: $(DEFAULT_WASM_LIBS)
 .DEFAULT_GOAL := default
 
 .PHONY: all
-all: default $(OPTIONAL_WASM_LIBS) $(WASM)/usr/share/fonts
+all: default $(OPTIONAL_WASM_LIBS) fonts
 
 $(EM_PKG_CONFIG_PATH)/%.pc: recipes/**/%.pc
 	mkdir -p $(EM_PKG_CONFIG_PATH)

--- a/libs/recipes/fontconfig/rules.mk
+++ b/libs/recipes/fontconfig/rules.mk
@@ -10,15 +10,21 @@ $(FC_TARBALL):
 	wget -q -O $@ $(FC_URL)
 
 $(FC_DEPS): $(FC_TARBALL) $(LIBXML2_WASM_LIB) $(EM_PKG_CONFIG_PATH)/freetype2.pc
+	rm -rf $(BUILD)/fontconfig-$(FC_VERSION)
 	mkdir -p $(BUILD)/fontconfig-$(FC_VERSION)/build
 	tar -C $(BUILD) -xf $(FC_TARBALL) --exclude=fcobjshash.h
-	cd $(BUILD)/fontconfig-$(FC_VERSION)/build && \
+	cp -r "$(WEBR_ROOT)/patches/fontconfig-$(FC_VERSION)/." \
+	  "$(BUILD)/fontconfig-$(FC_VERSION)/patches"
+	cd $(BUILD)/fontconfig-$(FC_VERSION)/build && quilt push -a && \
 	  LDFLAGS="$(LDFLAGS) -sUSE_FREETYPE=1 -sUSE_PTHREADS=0" \
 	  PTHREAD_CFLAGS=" " \
 	  emconfigure ../configure \
 	    ac_cv_func_fstatfs=no \
+	    ac_cv_func_link=no \
 	    --enable-shared=no \
 	    --enable-static=yes \
 	    --enable-libxml2 \
 	    --prefix=$(WASM) && \
 	  emmake make RUN_FC_CACHE_TEST=false install
+	cd $(BUILD)/fontconfig-$(FC_VERSION)/build/fc-cache && \
+	  make clean && make AM_LDFLAGS="-s NODERAWFS=1"

--- a/libs/recipes/fonts/fonts.conf
+++ b/libs/recipes/fonts/fonts.conf
@@ -1,22 +1,42 @@
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
 <fontconfig>
+    <dir>/usr/share/fonts</dir>
+    <dir>/home/web_user/fonts</dir>
+    <cachedir>/var/cache/fontconfig</cachedir>
+
+    <alias>
+        <family>Helvetica</family>
+        <prefer><family>sans-serif</family></prefer>
+    </alias>
+    <alias>
+        <family>Times</family>
+        <prefer><family>serif</family></prefer>
+    </alias>
+    <alias>
+        <family>Courier</family>
+        <prefer><family>monospace</family></prefer>
+    </alias>
+
+    <alias>
+        <family>sans</family>
+        <prefer><family>sans-serif</family></prefer>
+    </alias>
+    <alias>
+        <family>mono</family>
+        <prefer><family>monospace</family></prefer>
+    </alias>
+
     <alias>
         <family>sans-serif</family>
-        <prefer>
-            <family>Noto Sans</family>
-        </prefer>
+        <prefer><family>Noto Sans</family></prefer>
     </alias>
     <alias>
         <family>serif</family>
-        <prefer>
-            <family>Noto Serif</family>
-        </prefer>
+        <prefer><family>Noto Serif</family></prefer>
     </alias>
     <alias>
         <family>monospace</family>
-        <prefer>
-            <family>Noto Sans Mono</family>
-        </prefer>
+        <prefer><family>Noto Sans Mono</family></prefer>
     </alias>
 </fontconfig>

--- a/libs/recipes/fonts/rules.mk
+++ b/libs/recipes/fonts/rules.mk
@@ -1,5 +1,10 @@
 .PHONY: fonts
-fonts: $(WASM)/usr/share/fonts
+fonts: $(WASM)/usr/share/fonts $(FC_WASM_LIB)
+	rm -rf "$(WASM)/var/cache/fontconfig"
+	cp recipes/fonts/fonts.conf "$(WASM)/etc/fonts/fonts.conf"
+	node $(BUILD)/fontconfig-$(FC_VERSION)/build/fc-cache/fc-cache \
+	  -y "$(WASM)" -r -f -v /usr/share/fonts
+	rm -rf "$(WASM)/etc/fonts/conf.d" "$(WASM)/etc/fonts/fonts.conf.bak"
 
 $(WASM)/usr/share/fonts:
 	mkdir -p "$(FONTS)" "$(WASM)/usr/share/fonts" "$(WASM)/etc/fonts/"
@@ -20,8 +25,7 @@ $(WASM)/usr/share/fonts:
 	unzip -p $(FONTS)/NotoSansMono.zip static/NotoSansMono/NotoSansMono-Bold.ttf > $(FONTS)/NotoSansMono-Bold.ttf
 	rm $(FONTS)/NotoSansMono.zip
 	cp -r "$(FONTS)/." "$(WASM)/usr/share/fonts"
-	cp recipes/fonts/fonts.conf "$(WASM)/etc/fonts/local.conf"
 
 .PHONY: clean-fonts
 clean-fonts:
-	rm -rf "$(FONTS)" "$(WASM)/usr/share/fonts" "$(WASM)/etc/fonts/local.conf"
+	rm -rf "$(FONTS)" "$(WASM)/usr/share/fonts" "$(WASM)/var/cache/fontconfig"

--- a/libs/recipes/fonts/targets.mk
+++ b/libs/recipes/fonts/targets.mk
@@ -1,1 +1,2 @@
 WASM_LAZY_VFS += -f "$(WASM)/usr/share/fonts@/usr/share/fonts"
+WASM_LAZY_VFS += -f "$(WASM)/var/cache/fontconfig@/var/cache/fontconfig"

--- a/patches/fontconfig-2.12.5/fix-double-sysroot.diff
+++ b/patches/fontconfig-2.12.5/fix-double-sysroot.diff
@@ -1,0 +1,14 @@
+Index: fontconfig-2.12.5/src/fcxml.c
+===================================================================
+--- fontconfig-2.12.5.orig/src/fcxml.c
++++ fontconfig-2.12.5/src/fcxml.c
+@@ -3372,9 +3372,6 @@ FcConfigParseAndLoad (FcConfig	    *config,
+ 	ret = FcTrue;
+ 	goto bail0;
+     }
+-    if (sysroot)
+-	filename = FcStrBuildFilename (sysroot, f, NULL);
+-    else
+ 	filename = FcStrdup (f);
+     FcStrFree (f);
+ 

--- a/patches/fontconfig-2.12.5/series
+++ b/patches/fontconfig-2.12.5/series
@@ -1,0 +1,2 @@
+syscache-always-valid.diff
+fix-double-sysroot.diff

--- a/patches/fontconfig-2.12.5/syscache-always-valid.diff
+++ b/patches/fontconfig-2.12.5/syscache-always-valid.diff
@@ -1,0 +1,13 @@
+Index: fontconfig-2.12.5/src/fccache.c
+===================================================================
+--- fontconfig-2.12.5.orig/src/fccache.c
++++ fontconfig-2.12.5/src/fccache.c
+@@ -584,7 +584,7 @@ FcCacheTimeValid (FcConfig *config, FcCache *cache, st
+ 	printf ("FcCacheTimeValid dir \"%s\" cache checksum %d dir checksum %d\n",
+ 		FcCacheDir (cache), cache->checksum, (int) dir_stat->st_mtime);
+ #endif
+-
++    if (strcmp(FcCacheDir(cache), "/usr/share/fonts") == 0) return FcTrue;
+     return cache->checksum == (int) dir_stat->st_mtime && fnano;
+ }
+ 


### PR DESCRIPTION
A follow up to #221 

Bitmap plotting with e.g. `png()` will cause fontconfig to scan the contents of `/usr/share/fonts`, triggering a download of all font files on the lazy VFS.

With this PR, a font info cache is instead generated as part of the fontconfig build process and included in the VFS. Fontconfig itself has also been patched to always accept this cache as valid, working around an issue with Emscripten FS timestamps. If required, extra fonts can still be added under `/home/web_user/fonts` by the user, as the font cache patch only applies to `/usr/share/fonts`.

The `fonts.conf` configuration file has also been updated to better handle "well-known" font names and point to the new font and cache directories.

This fixes lazy font downloading, only the font cache and the required font(s) will be downloaded for plotting with Cairo. This means that in the future we can distribute with webR many large font files for internationalisation. IIUC fontconfig will be able to figure out from the information provided by the font cache if the default fonts are missing any required glyphs (e.g. during Arabic or CJK text rendering) and download alternative fonts containing the glyphs on demand.