### PR TITLE
Add custom error classes to be thrown by webR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 * Add a `quiet` argument to `webr::install()` and `webR.installPackages()` APIs that allows for silencing webR package downloading messages.
 
+* Add custom `WebRError` classes so that errors from webR can be identified by testing thrown exceptions with `instanceof WebRError`.
+
 ## Breaking changes
 
  * Removed the legacy `console.mjs` build target. The `Console` class is re-exported on the default `WebR` entrypoint, and so the extra build target is not required. This is technically a breaking change, but the legacy entrypoint was never documented and so we believe the change has only minor effect.

--- a/src/tests/webR/error.test.ts
+++ b/src/tests/webR/error.test.ts
@@ -1,0 +1,39 @@
+import { WebR, WebRError, WebRWorkerError } from '../../webR/webr-main';
+
+const webR = new WebR({
+  baseUrl: '../dist/',
+  RArgs: ['--quiet'],
+});
+
+beforeAll(async () => {
+  await webR.init();
+});
+
+test('Errors from webR are instances of WebRError', async () => {
+  const problem = webR.evalRNumber('"abc"');
+  await expect(problem).rejects.toThrow(WebRError);
+  await expect(problem).rejects.toThrow("Can't convert object of type character to number");
+});
+
+test('Errors forwarded from the worker thread are instances of WebRWorkerError', async () => {
+  const problem = webR.evalR('1+');
+  await expect(problem).rejects.toThrow(WebRWorkerError);
+  await expect(problem).rejects.toThrow('unexpected end of input');
+});
+
+test('Caught WebRError has the expected error name property', async () => {
+  let error: Error | undefined;
+  try {
+    await webR.evalR('1+');
+  } catch (e) {
+    if (e instanceof WebRError) {
+      error = e;
+    }
+  }
+  expect(error).toHaveProperty('name', 'WebRWorkerError');
+  expect(error).toHaveProperty('message', expect.stringContaining('unexpected end of input'));
+});
+
+afterAll(() => {
+  return webR.close();
+});

--- a/src/webR/chan/channel-common.ts
+++ b/src/webR/chan/channel-common.ts
@@ -2,6 +2,7 @@ import { SharedBufferChannelMain, SharedBufferChannelWorker } from './channel-sh
 import { ServiceWorkerChannelMain, ServiceWorkerChannelWorker } from './channel-service';
 import { WebROptions } from '../webr-main';
 import { isCrossOrigin } from '../utils';
+import { WebRChannelError } from '../error';
 
 // This file refers to objects imported from `./channel-shared` and
 // `./channel-service.` These can't be included in `./channel` as this
@@ -45,7 +46,7 @@ export function newChannelMain(data: Required<WebROptions>) {
       if ('serviceWorker' in navigator && !isCrossOrigin(data.serviceWorkerUrl)) {
         return new ServiceWorkerChannelMain(data);
       }
-      throw new Error("Can't initialise main thread communication channel");
+      throw new WebRChannelError("Can't initialise main thread communication channel");
   }
 }
 
@@ -56,6 +57,6 @@ export function newChannelWorker(msg: ChannelInitMessage) {
     case ChannelType.ServiceWorker:
       return new ServiceWorkerChannelWorker(msg.data);
     default:
-      throw new Error('Unknown worker channel type recieved');
+      throw new WebRChannelError('Unknown worker channel type recieved');
   }
 }

--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -11,6 +11,7 @@ import { Endpoint } from './task-common';
 import { ChannelMain, ChannelWorker } from './channel';
 import { ChannelType } from './channel-common';
 import { WebROptions } from '../webr-main';
+import { WebRChannelError } from '../error';
 
 import { IN_NODE } from '../compat';
 import type { Worker as NodeWorker } from 'worker_threads';
@@ -68,7 +69,7 @@ export class ServiceWorkerChannelMain extends ChannelMain {
 
   activeRegistration(): ServiceWorker {
     if (!this.#registration?.active) {
-      throw new Error('Attempted to obtain a non-existent active registration.');
+      throw new WebRChannelError('Attempted to obtain a non-existent active registration.');
     }
     return this.#registration.active;
   }
@@ -111,7 +112,7 @@ export class ServiceWorkerChannelMain extends ChannelMain {
       const uuid = event.data.data as string;
       const message = this.#syncMessageCache.get(uuid);
       if (!message) {
-        throw new Error('Request not found during service worker XHR request');
+        throw new WebRChannelError('Request not found during service worker XHR request');
       }
       this.#syncMessageCache.delete(uuid);
       switch (message.type) {
@@ -136,7 +137,7 @@ export class ServiceWorkerChannelMain extends ChannelMain {
           break;
         }
         default:
-          throw new TypeError(`Unsupported request type '${message.type}'.`);
+          throw new WebRChannelError(`Unsupported request type '${message.type}'.`);
       }
       return;
     }
@@ -182,7 +183,7 @@ export class ServiceWorkerChannelMain extends ChannelMain {
       }
 
       case 'request':
-        throw new TypeError(
+        throw new WebRChannelError(
           "Can't send messages of type 'request' from a worker." +
             'Use service worker fetch request instead.'
         );
@@ -204,7 +205,7 @@ export class ServiceWorkerChannelWorker implements ChannelWorker {
 
   constructor(data: { clientId?: string; location?: string }) {
     if (!data.clientId || !data.location) {
-      throw Error("Can't start service worker channel");
+      throw new WebRChannelError("Can't start service worker channel");
     }
     this.#mainThreadId = data.clientId;
     this.#location = data.location;

--- a/src/webR/chan/channel-shared.ts
+++ b/src/webR/chan/channel-shared.ts
@@ -5,6 +5,7 @@ import { syncResponse } from './task-main';
 import { ChannelMain, ChannelWorker } from './channel';
 import { ChannelType } from './channel-common';
 import { WebROptions } from '../webr-main';
+import { WebRChannelError } from '../error';
 
 import { IN_NODE } from '../compat';
 import type { Worker as NodeWorker } from 'worker_threads';
@@ -50,7 +51,7 @@ export class SharedBufferChannelMain extends ChannelMain {
 
   interrupt() {
     if (!this.#interruptBuffer) {
-      throw new Error('Failed attempt to interrupt before initialising interruptBuffer');
+      throw new WebRChannelError('Failed attempt to interrupt before initialising interruptBuffer');
     }
     this.inputQueue.reset();
     this.#interruptBuffer[0] = 1;
@@ -102,12 +103,12 @@ export class SharedBufferChannelMain extends ChannelMain {
             break;
           }
           default:
-            throw new TypeError(`Unsupported request type '${payload.type}'.`);
+            throw new WebRChannelError(`Unsupported request type '${payload.type}'.`);
         }
         return;
       }
       case 'request':
-        throw new TypeError(
+        throw new WebRChannelError(
           "Can't send messages of type 'request' from a worker. Please Use 'sync-request' instead."
         );
     }

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -6,7 +6,7 @@
 import { promiseHandles, ResolveFn, RejectFn } from '../utils';
 import { AsyncQueue } from './queue';
 import { Message, newRequest, Response } from './message';
-import { WebRPayload, WebRPayloadWorker, webRPayloadError } from '../payload';
+import { WebRPayload, WebRPayloadWorker, webRPayloadAsError } from '../payload';
 
 // The channel structure is asymetric:
 //
@@ -82,7 +82,7 @@ export abstract class ChannelMain {
       this.#parked.delete(uuid);
 
       if (payload.payloadType === 'err') {
-        handles.reject(webRPayloadError(payload));
+        handles.reject(webRPayloadAsError(payload));
       } else {
         handles.resolve(payload);
       }

--- a/src/webR/chan/serviceworker.ts
+++ b/src/webR/chan/serviceworker.ts
@@ -1,6 +1,7 @@
 import { promiseHandles } from '../utils';
 import { encode, decode } from '@msgpack/msgpack';
 import { ServiceWorkerHandlers } from './channel';
+import { WebRChannelError } from '../error';
 
 declare let self: ServiceWorkerGlobalScope;
 
@@ -25,7 +26,7 @@ export function handleActivate(event: ExtendableEvent) {
 async function sendRequest(clientId: string, uuid: string): Promise<Response> {
   const client = await self.clients.get(clientId);
   if (!client) {
-    throw new Error('Service worker client not found');
+    throw new WebRChannelError('Service worker client not found');
   }
 
   if (!(uuid in requests)) {
@@ -62,7 +63,7 @@ export function handleMessage(event: ExtendableMessageEvent) {
       const source = event.source as WindowClient;
       self.clients.get(source.id).then((client) => {
         if (!client) {
-          throw new Error("Can't respond to client in service worker message handler");
+          throw new WebRChannelError("Can't respond to client in service worker message handler");
         }
         client.postMessage({
           type: 'registration-successful',

--- a/src/webR/compat.ts
+++ b/src/webR/compat.ts
@@ -1,3 +1,5 @@
+import { WebRError } from './error';
+
 interface Process {
   browser: string | undefined;
   release: { [key: string]: string };
@@ -38,5 +40,5 @@ if (globalThis.document) {
     await import(nodePathMod.resolve(url));
   };
 } else {
-  throw new Error('Cannot determine runtime environment');
+  throw new WebRError('Cannot determine runtime environment');
 }

--- a/src/webR/error.ts
+++ b/src/webR/error.ts
@@ -24,3 +24,8 @@ export class WebRWorkerError extends WebRError {}
  * Exceptions related to issues with the webR communication channel.
  */
 export class WebRChannelError extends WebRError {}
+
+/**
+ * Exceptions related to issues with webR object payloads.
+ */
+export class WebRPayloadError extends WebRError {}

--- a/src/webR/error.ts
+++ b/src/webR/error.ts
@@ -1,0 +1,21 @@
+/**
+ * Custom Error classes that shall be raised by webR.
+ * @module Error
+ */
+
+/**
+ * A general error raised by webR.
+ */
+export class WebRError extends Error {
+  constructor(msg: string) {
+      super(msg);
+      this.name = this.constructor.name;
+      Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Exceptions raised on the webR worker thread that have been forwarded to the
+ * main thread through the communication channel.
+ */
+export class WebRWorkerError extends WebRError {}

--- a/src/webR/error.ts
+++ b/src/webR/error.ts
@@ -19,3 +19,8 @@ export class WebRError extends Error {
  * main thread through the communication channel.
  */
 export class WebRWorkerError extends WebRError {}
+
+/**
+ * Exceptions related to issues with the webR communication channel.
+ */
+export class WebRChannelError extends WebRError {}

--- a/src/webR/payload.ts
+++ b/src/webR/payload.ts
@@ -4,6 +4,7 @@
  * @module Payload
  */
 import { WebRDataRaw, RPtr, RType } from './robj';
+import { WebRWorkerError } from './error';
 
 export type WebRPayloadRaw = {
   obj: WebRDataRaw;
@@ -35,8 +36,11 @@ export type WebRPayloadWorker = WebRPayloadRaw | WebRPayloadPtr | WebRPayloadErr
 
 /* @internal */
 export function webRPayloadError(payload: WebRPayloadErr): Error {
-  const e = new Error(payload.obj.message);
-  e.name = payload.obj.name;
+  const e = new WebRWorkerError(payload.obj.message);
+  // Forward the error name to the main thread, if more specific than a general `Error`
+  if (payload.obj.name !== 'Error') {
+    e.name = payload.obj.name;
+  }
   e.stack = payload.obj.stack;
   return e;
 }

--- a/src/webR/payload.ts
+++ b/src/webR/payload.ts
@@ -35,7 +35,7 @@ export type WebRPayload = WebRPayloadRaw | WebRPayloadPtr;
 export type WebRPayloadWorker = WebRPayloadRaw | WebRPayloadPtr | WebRPayloadErr;
 
 /* @internal */
-export function webRPayloadError(payload: WebRPayloadErr): Error {
+export function webRPayloadAsError(payload: WebRPayloadErr): Error {
   const e = new WebRWorkerError(payload.obj.message);
   // Forward the error name to the main thread, if more specific than a general `Error`
   if (payload.obj.name !== 'Error') {

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -11,7 +11,7 @@ import { isRObject, RObject, isRFunction } from './robj-main';
 import * as RWorker from './robj-worker';
 import { ShelterID, CallRObjectMethodMessage, NewRObjectMessage } from './webr-chan';
 import type * as Payload from './payload';
-import { WebRError } from './error';
+import { WebRError, WebRPayloadError } from './error';
 
 /**
  * Obtain a union of the keys corresponding to methods of a given class `T`.
@@ -195,7 +195,7 @@ async function newRObject(
   const payload = await chan.request(msg);
   switch (payload.payloadType) {
     case 'raw':
-      throw new Error('Unexpected raw payload type returned from newRObject');
+      throw new WebRPayloadError('Unexpected raw payload type returned from newRObject');
     case 'ptr':
       return newRProxy(chan, payload);
   }

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -11,6 +11,7 @@ import { isRObject, RObject, isRFunction } from './robj-main';
 import * as RWorker from './robj-worker';
 import { ShelterID, CallRObjectMethodMessage, NewRObjectMessage } from './webr-chan';
 import type * as Payload from './payload';
+import { WebRError } from './error';
 
 /**
  * Obtain a union of the keys corresponding to methods of a given class `T`.
@@ -120,7 +121,7 @@ function targetAsyncIterator(chan: ChannelMain, proxy: RProxy<RWorker.RObject>) 
 
     // Throw an error if there was some problem accessing the object length
     if (typeof reply.obj !== 'number') {
-      throw new Error('Cannot iterate over object, unexpected type for length property.');
+      throw new WebRError('Cannot iterate over object, unexpected type for length property.');
     }
 
     // Loop through the object and yield values

--- a/src/webR/utils.ts
+++ b/src/webR/utils.ts
@@ -1,4 +1,5 @@
 import { IN_NODE } from './compat';
+import { WebRError } from './error';
 
 export type ResolveFn = (_value?: unknown) => void;
 export type RejectFn = (_reason?: any) => void;
@@ -86,5 +87,5 @@ export function throwUnreachable(context?: string) {
   let msg = 'Reached the unreachable';
   msg = msg + (context ? ': ' + context : '.');
 
-  throw new Error(msg);
+  throw new WebRError(msg);
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -15,7 +15,7 @@ import { REnvironment, RSymbol, RInteger } from './robj-main';
 import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString, RCall } from './robj-main';
 import { replaceInObject } from './utils';
 import * as RWorker from './robj-worker';
-import { WebRError } from './error';
+import { WebRError, WebRPayloadError } from './error';
 
 import {
   CaptureRMessage,
@@ -409,7 +409,7 @@ export class WebR {
       case 'raw':
         return payload.obj;
       case 'ptr':
-        throw new Error('Unexpected ptr payload type returned from evalRVoid');
+        throw new WebRPayloadError('Unexpected ptr payload type returned from evalRVoid');
     }
   }
 
@@ -549,7 +549,7 @@ export class Shelter {
 
     switch (payload.payloadType) {
       case 'raw':
-        throw new Error('Unexpected payload type returned from evalR');
+        throw new WebRPayloadError('Unexpected payload type returned from evalR');
       default:
         return newRProxy(this.#chan, payload);
     }
@@ -583,7 +583,7 @@ export class Shelter {
 
     switch (payload.payloadType) {
       case 'ptr':
-        throw new Error('Unexpected payload type returned from evalR');
+        throw new WebRPayloadError('Unexpected payload type returned from evalR');
 
       case 'raw': {
         const data = payload.obj as {

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -15,6 +15,7 @@ import { REnvironment, RSymbol, RInteger } from './robj-main';
 import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString, RCall } from './robj-main';
 import { replaceInObject } from './utils';
 import * as RWorker from './robj-worker';
+import { WebRError } from './error';
 
 import {
   CaptureRMessage,
@@ -281,7 +282,7 @@ export class WebR {
           console.error(msg.data);
           break;
         default:
-          throw new Error('Unknown system message type `' + msg.type + '`');
+          throw new WebRError('Unknown system message type `' + msg.type + '`');
       }
     }
   }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -33,6 +33,7 @@ import {
 
 export { Console, ConsoleCallbacks } from './console';
 export * from './robj-main';
+export * from './error';
 
 /**
  * The webR FS API for interacting with the Emscripten Virtual File System.


### PR DESCRIPTION
Closes #206.

A new class `WebRError` is introduced, extending the built-in JS `Error` class. The new error class is then further extended for more specific errors `WebRWorkerError`, `WebRChannelError`, and `WebRPayloadError`.

WebR errors thrown on the main thread have been changed to use the new `WebRError` classes.

Errors thrown on the worker thread have not been changed, but they are caught internally and forwarded to the main thread in any case. Any errors forwarded in this way are rethrown on the main thread as an instance of `WebRWorkerError`.

If an error more specific than `Error` is thrown on the worker thread, that error name is also forwarded to the main thread. Otherwise, the default error name of `WebRWorkerError` is used so as to match the class of the error, as expected.

The new error classes are exposed on the main webR entrypoint so that end-users can easily grab the classes for testing with `instanceof`.

With this, users can catch webR errors specifically, distinguishing them from other JavaScript errors. Useful for handling things like R syntax errors differently. For example,

``` js
import { WebR, WebRError } from '@r-wasm/webr';
[ ... init webR ...]

try {
  const val = await webR.evalRNumber(someRCode);
  // Do something with val
} except (e) {
  if (e instanceof WebRError) {
    // some webR error when evaluating the R code
  } else {
    // some other JS error when working with val
  }
}
```