### PR TITLE
Generalise `canvas` messages to support different "events"

### DIFF
--- a/packages/webr/R/canvas.R
+++ b/packages/webr/R/canvas.R
@@ -21,6 +21,6 @@
 #' @param pointsize	The default point size of plotted text.
 #' @param bg The initial background colour.
 #' @param ... Additional graphics device arguments (ignored).
-canvas <- function(width=504, height=504, pointsize=12, bg="white", ...) {
+canvas <- function(width=504, height=504, pointsize=12, bg="transparent", ...) {
   .Call(ffi_dev_canvas, width, height, pointsize, bg)
 }

--- a/packages/webr/src/canvas.c
+++ b/packages/webr/src/canvas.c
@@ -185,7 +185,7 @@ void canvasMode(int mode, pDevDesc RGD) {
         canvasDesc *cGD = (canvasDesc *)RGD->deviceSpecific;
         EM_ASM({
             const image = Module.offscreenCanvas.transferToImageBitmap();
-            chan.write({ type: 'canvasImage', data: { image } }, [image]);
+            chan.write({ type: 'canvas', data: { event: 'canvasImage', image } }, [image]);
         });
     }
     return;
@@ -206,6 +206,10 @@ void canvasNewPage(const pGEcontext gc, pDevDesc RGD)
             Module.canvasCtx.fillRect(0, 0, $0, $1);
         }, 2*RGD->right, 2*RGD->bottom);
     }
+
+    EM_ASM({
+        chan.write({ type: 'canvas', data: { event: 'canvasNewPage' } });
+    });
 }
 
 void canvasPolygon(int n, double *x, double *y,

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -178,14 +178,14 @@ const webR = new WebR({
         console.log(`Loading package: ${output.data as string}`);
         FSTree.refresh();
         break;
-      case 'canvasExec':
-        Function(`
-           document.getElementById('plot-canvas').getContext('2d').${output.data as string}
-         `)();
-        break;
-      case 'canvasImage': {
+      case 'canvas': {
         const canvas = document.getElementById('plot-canvas') as HTMLCanvasElement;
-        canvas.getContext('2d')!.drawImage(output.data.image as ImageBitmap, 0, 0);
+        const context = canvas.getContext('2d');
+        if (output.data.event === 'canvasImage') {
+          context!.drawImage(output.data.image as ImageBitmap, 0, 0);
+        } else if (output.data.event === 'canvasNewPage') {
+          context!.clearRect(0, 0, canvas.width, canvas.height);
+        }
         break;
       }
       case 'closed':

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -1,5 +1,6 @@
 import { initFSTree, FSTreeInterface, JSTreeNode } from './fstree';
 import { WebR, FSNode } from '../webR/webr-main';
+import { CanvasMessage } from '../webR/webr-chan';
 
 import 'xterm/css/xterm.css';
 import { Terminal } from 'xterm';
@@ -181,9 +182,10 @@ const webR = new WebR({
       case 'canvas': {
         const canvas = document.getElementById('plot-canvas') as HTMLCanvasElement;
         const context = canvas.getContext('2d');
-        if (output.data.event === 'canvasImage') {
-          context!.drawImage(output.data.image as ImageBitmap, 0, 0);
-        } else if (output.data.event === 'canvasNewPage') {
+        const msgData = output.data as CanvasMessage['data'];
+        if (msgData.event === 'canvasImage') {
+          context!.drawImage(msgData.image, 0, 0);
+        } else if (msgData.event === 'canvasNewPage') {
           context!.clearRect(0, 0, canvas.width, canvas.height);
         }
         break;

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -153,3 +153,13 @@ export interface ShelterDestroyMessage extends Message {
   type: 'shelterDestroy';
   data: { id: ShelterID; obj: WebRPayloadPtr };
 }
+
+export interface CanvasMessage extends Message {
+  type: 'canvas',
+  data: {
+    event: 'canvasNewPage';
+  } | {
+    event: 'canvasImage';
+    image: ImageBitmap;
+  };
+}


### PR DESCRIPTION
See discussion from https://github.com/r-wasm/webr/issues/154#issuecomment-1628684429 for context.

It would be good to be able to signal to the main thread when the canvas graphics device has created a new page when plotting. This allows the main thread to better manage the state when multiple plots are generated. In the current implementation the backing `OffscreenCanvas` is cleared when a new plot is made, but no other signal is given.

This PR generalises the messaging from the canvas device to be able to signal different types of "event". Two types of event are now emitted,
 * `canvasImage` - as before, sending an `ImageBitmap` to the main thread for display.
 * `canvasNewPage` - emitted when the graphics device creates a new and empty page for plotting.

A `CanvasMessage` interface is added for typing under TypeScript, and as the canvas device is developed, further events can be added to match the scheme.

With this, the default background colour can also be made to be transparent again (since the main thread can now clear the current plot properly at the right time by listening for a `canvasNewPage` event).