### PR TITLE
Autocomplete and "Run Code" shortcut for the REPL app editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 * Add custom `WebRError` classes so that errors from webR can be identified by testing thrown exceptions with `instanceof WebRError`.
 
+* Reimplemented the demo webR REPL app using the React framework, allowing us to drop jQuery as a dependency. The reworked app has various new features and improvements: now includes a tabbed CodeMirror editor with R syntax highlighting and autocomplete, support for text document paging and displaying built-in R help/demos/documentation, expanded UI for virtual filesystem management, improved plot handling including paged multiple plots.
+
 ## Breaking changes
 
  * Removed the legacy `console.mjs` build target. The `Console` class is re-exported on the default `WebR` entrypoint, and so the extra build target is not required. This is technically a breaking change, but the legacy entrypoint was never documented and so we believe the change has only minor effect.

--- a/src/repl/components/Editor.css
+++ b/src/repl/components/Editor.css
@@ -15,6 +15,7 @@
   background-color: transparent;
   border: none;
   color: var(--secondary);
+  font-size: 14px;
 }
 
 .editor-actions > button:hover {

--- a/src/repl/components/Editor.tsx
+++ b/src/repl/components/Editor.tsx
@@ -93,7 +93,6 @@ export function Editor({
   }>(null);
 
   React.useEffect(() => {
-    if (!webR) return;
     let shelter: Shelter | null = null;
 
     webR.init().then(async () => {
@@ -112,10 +111,12 @@ export function Editor({
     return function cleanup() {
       if (shelter) shelter.purge();
     };
-  }, [webR]);
+  }, []);
 
   const completion = React.useCallback(async (context: CompletionContext) => {
-    if (!webR || !completionMethods.current) return null;
+    if (!completionMethods.current) {
+      return null;
+    }
     const line = context.state.doc.lineAt(context.state.selection.main.head).text;
     const {from, to, text} = context.matchBefore(/[a-zA-Z0-9_.:]*/) ?? {from: 0, to: 0, text: ''};
     if (from === to && !context.explicit) {
@@ -135,7 +136,7 @@ export function Editor({
     });
 
     return { from: from, options };
-  }, [webR]);
+  }, []);
 
   const editorExtensions = [
     basicSetup,
@@ -168,7 +169,9 @@ export function Editor({
 
   React.useEffect(() => {
     runSelectedCode.current = (): void => {
-      if (!editorView || !webR) return;
+      if (!editorView) {
+        return;
+      }
       let code = utils.getSelectedText(editorView);
       if (code === '') {
         code = utils.getCurrentLineText(editorView);
@@ -176,7 +179,7 @@ export function Editor({
       }
       webR.writeConsole(code);
     };
-  }, [webR, editorView]);
+  }, [editorView]);
 
   const syncActiveFileState = React.useCallback(() => {
     if (!editorView || !activeFile) {
@@ -208,7 +211,7 @@ export function Editor({
       await webR.FS.writeFile(activeFile.path, data);
       filesInterface.refreshFilesystem();
     })();
-  }, [webR, syncActiveFileState, editorView]);
+  }, [syncActiveFileState, editorView]);
 
   React.useEffect(() => {
     if (!editorRef.current) {

--- a/src/repl/components/Files.css
+++ b/src/repl/components/Files.css
@@ -18,6 +18,7 @@
   border: none;
   color: var(--secondary);
   padding: 5px;
+  font-size: 14px;
 }
 
 .files-actions > button:hover {

--- a/src/repl/components/Plot.css
+++ b/src/repl/components/Plot.css
@@ -37,6 +37,7 @@
   border: none;
   color: var(--secondary);
   padding: 5px;
+  font-size: 14px;
 }
 
 .plot-actions > button:hover {

--- a/src/repl/components/utils.ts
+++ b/src/repl/components/utils.ts
@@ -1,0 +1,56 @@
+// Originally from src/Components/codeMirror/utils.ts in rstudio/shinylive
+// MIT License - Copyright (c) 2022 RStudio, PBC
+
+import { Text } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+export type CursorPosition = { line: number; col: number };
+
+export function offsetToPosition(cmDoc: Text, offset: number): CursorPosition {
+  const line = cmDoc.lineAt(offset);
+  return { line: line.number, col: offset - line.from };
+}
+
+export function positionToOffset(cmDoc: Text, pos: CursorPosition): number {
+  const line = cmDoc.line(pos.line);
+  // Try go to the next computed position (line.from + pos.col), but don't go
+  // past the end of the line (line.to).
+  const newOffset = Math.min(line.from + pos.col, line.to);
+
+  // If the new offset is beyond the end of the document, just go to the end.
+  if (newOffset > cmDoc.length) {
+    return cmDoc.length;
+  }
+  return newOffset;
+}
+
+export function getSelectedText(cmView: EditorView): string {
+  const cmState = cmView.state;
+  return cmState.sliceDoc(
+    cmState.selection.main.from,
+    cmState.selection.main.to
+  );
+}
+
+export function getCurrentLineText(cmView: EditorView): string {
+  const cmState = cmView.state;
+  const offset = cmState.selection.main.head;
+  const pos = offsetToPosition(cmState.doc, offset);
+  const lineText = cmState.doc.line(pos.line).text;
+  return lineText;
+}
+
+export function moveCursorToNextLine(cmView: EditorView): void {
+  const cmState = cmView.state;
+  const offset = cmState.selection.main.head;
+  const pos = offsetToPosition(cmState.doc, offset);
+  pos.line += 1;
+
+  // Don't go past the bottom
+  if (pos.line > cmState.doc.lines) {
+    return;
+  }
+
+  const nextLineOffset = positionToOffset(cmState.doc, pos);
+  cmView.dispatch({ selection: { anchor: nextLineOffset } });
+}


### PR DESCRIPTION
Depends on #241.

Adds autocompletion to the webR REPL editor by hooking up CodeMirror's autocomplete features to R's built-in [rcompgen](https://stat.ethz.ch/R-manual/R-devel/library/utils/html/rcompgen.html) functionality.

This works by grabbing references to the rcompgen functions as webR `RFunction` objects, protecting them with a `Shelter`, and invoking them from the JavaScript environment to return completion results for CodeMirror to use.