### PR TITLE
Use repo's binary contrib URL to list available webR packages in `webr::install()`

### DIFF
--- a/packages/webr/R/install.R
+++ b/packages/webr/R/install.R
@@ -13,7 +13,12 @@ install <- function(packages, repos = NULL, lib = NULL, quiet = FALSE) {
   if (is.null(repos)) {
     repos <- getOption("webr_pkg_repos")
   }
-  info <- utils::available.packages(repos = repos, type = "source")
+
+  ver <- as.character(getRversion())
+  ver <- gsub("\\.[^.]+$", "", ver)
+
+  contrib <- sprintf("%s/bin/emscripten/contrib/%s", repos[[1]], ver)
+  info <- utils::available.packages(contriburl = contrib)
   deps <- unlist(tools::package_dependencies(packages, info), use.names = FALSE)
   deps <- unique(deps)
 
@@ -34,12 +39,7 @@ install <- function(packages, repos = NULL, lib = NULL, quiet = FALSE) {
       next
     }
 
-    ver <- as.character(getRversion())
-    ver <- gsub("\\.[^.]+$", "", ver)
-    bin_suffix <- sprintf("bin/emscripten/contrib/%s", ver)
-
     repo <- info[pkg, "Repository"]
-    repo <- sub("src/contrib", bin_suffix, repo, fixed = TRUE)
     repo <- sub("file:", "", repo, fixed = TRUE)
 
     pkg_ver <- info[pkg, "Version"]

--- a/packages/webr/R/install.R
+++ b/packages/webr/R/install.R
@@ -17,6 +17,7 @@ install <- function(packages, repos = NULL, lib = NULL, quiet = FALSE) {
   ver <- as.character(getRversion())
   ver <- gsub("\\.[^.]+$", "", ver)
 
+  repos <- gsub("/$", "", repos)
   contrib <- sprintf("%s/bin/emscripten/contrib/%s", repos[[1]], ver)
   info <- utils::available.packages(contriburl = contrib)
   deps <- unlist(tools::package_dependencies(packages, info), use.names = FALSE)


### PR DESCRIPTION
Currently, `webr::install()` enumerates available packages by passing our CRAN-like repo URL to `available.packages()`. This uses the `/src` directory in the repo to find and list the available packages along with with their versions.

A URL is then built for binary download, by concatenating our CRAN-like repo's binary URL, R version, package name, and package version.

This breaks when using older webR releases, because an older version of webR (e.g. v0.1.1, with R 4.1.0) must use older builds of our repo's R package binaries[1]. Currently, these binaries are stored in our public repo under `bin/.../4.1`, with the latest packages in `src/...` and `bin/.../4.3`. So, as time moves on the package versions listed in `/src` and `/bin/.../4.1` become out of sync.

This PR tweaks `webr::install()` to use the `contriburl` argument of `available.packages()`, so that the package names and versions enumerated are the relevant binary versions, rather than the packages in `/src`. This way, when running an older version of webR, such as v0.1.1, the resulting binary download URLs continue to work even as packages are updated for the latest webR.

This should fix #245.

[1] In particular, these packages need to be built using an outdated version of the build process that uses an older build of Emscripten, and compiles with Wasm exceptions and assertions disabled.