### PR TITLE
Add fallback `postMessage` based communication channel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # webR (development version)
 
+## New features
+
+* Added a new communication channel based on `postMessage`, to be used when both Cross Origin Isolation and Service Workers are unavailable. Nested R REPLs (e.g. `readline()`, `menu()`, `browser()`, etc.) are unsupported when using this channel.
+
 ## Bug fixes
 
 * Fix HTML canvas graphics in `Console` class (#256).

--- a/packages/webr/R/handlers.R
+++ b/packages/webr/R/handlers.R
@@ -13,20 +13,24 @@
 #' interrupting the current program.
 #'
 #' @export
-global_prompt_install <- function() {
+global_prompt_install <- function(show_menu = TRUE) {
   globalCallingHandlers(
     packageNotFoundError = function(cnd) {
       if (!interactive()) {
         return()
       }
       pkg <- cnd$package
-      download <- utils::menu(
-        c("Yes", "No"),
-        title = paste0(
-          'Failed to load package "', pkg,
-          '". Do you want to try downloading it from the webR binary repo?'
+      if (!show_menu) {
+        download <- 1
+      } else {
+        download <- utils::menu(
+          c("Yes", "No"),
+          title = paste0(
+            'Failed to load package "', pkg,
+            '". Do you want to try downloading it from the webR binary repo?'
+          )
         )
-      )
+      }
       if (download == 1) {
         webr::install(pkg)
         tryInvokeRestart("retry_loadNamespace")

--- a/patches/R-4.3.0/emscripten-input.diff
+++ b/patches/R-4.3.0/emscripten-input.diff
@@ -1,7 +1,7 @@
-Index: R-4.2.2/src/unix/sys-std.c
+Index: R-4.3.0/src/unix/sys-std.c
 ===================================================================
---- R-4.2.2.orig/src/unix/sys-std.c
-+++ R-4.2.2/src/unix/sys-std.c
+--- R-4.3.0.orig/src/unix/sys-std.c
++++ R-4.3.0/src/unix/sys-std.c
 @@ -61,6 +61,7 @@
  
  #ifdef __EMSCRIPTEN__
@@ -10,7 +10,7 @@ Index: R-4.2.2/src/unix/sys-std.c
  #endif
  
  extern SA_TYPE SaveAction;
-@@ -325,8 +326,17 @@ static void nop(void){}
+@@ -325,8 +326,17 @@ void (* R_PolledEvents)(void) = nop;
  
  static void nop(void){}
  
@@ -28,7 +28,7 @@ Index: R-4.2.2/src/unix/sys-std.c
  
  /* For X11 devices */
  void (* Rg_PolledEvents)(void) = nop;
-@@ -1043,8 +1052,12 @@ Rstd_ReadConsole(const char *prompt, unsigned char *bu
+@@ -1043,8 +1053,12 @@ Rstd_ReadConsole(const char *prompt, unsigned char *bu
  	else
  #endif /* HAVE_LIBREADLINE */
  	{
@@ -41,7 +41,7 @@ Index: R-4.2.2/src/unix/sys-std.c
  	}
  
  	if(R_InputHandlers == NULL)
-@@ -1102,10 +1115,24 @@ Rstd_ReadConsole(const char *prompt, unsigned char *bu
+@@ -1102,10 +1116,25 @@ Rstd_ReadConsole(const char *prompt, unsigned char *bu
  		else
  #endif /* HAVE_LIBREADLINE */
  		{
@@ -52,11 +52,12 @@ Index: R-4.2.2/src/unix/sys-std.c
 +			initialised = 1;
 +		    }
 +		    const char* input = (const char*) EM_ASM_INT(return globalThis.Module.webr.readConsole());
-+
-+		    strncpy((char*) buf, input, len);
-+		    free((void*) input);
-+
-+		    return 1;
++		    if (input) {
++ 		        strncpy((char*) buf, input, len);
++		        free((void*) input);
++		        return 1;
++		    }
++		    return 0;
 +#else
  		    if(fgets((char *)buf, len, stdin) == NULL)
  			return 0;
@@ -66,3 +67,16 @@ Index: R-4.2.2/src/unix/sys-std.c
  		}
  	    }
  	}
+Index: R-4.3.0/src/main/main.c
+===================================================================
+--- R-4.3.0.orig/src/main/main.c
++++ R-4.3.0/src/main/main.c
+@@ -321,7 +321,7 @@ static unsigned char DLLbuf[CONSOLE_BUFFER_SIZE+1], *D
+ }
+ 
+ 
+-static unsigned char DLLbuf[CONSOLE_BUFFER_SIZE+1], *DLLbufp;
++unsigned char DLLbuf[CONSOLE_BUFFER_SIZE+1], *DLLbufp;
+ 
+ static void check_session_exit(void)
+ {

--- a/src/docs/communication.qmd
+++ b/src/docs/communication.qmd
@@ -16,11 +16,12 @@ Communication between the main thread and the webR worker thread is managed by m
 |-------------------|----------------------------|-------------------------|
 | `SharedArrayBuffer` (Default) | [Cross-origin Isolation](https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated)    | None                                                                                |
 | `ServiceWorker`               | [JavaScript service workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) | A service worker script must be hosted in the same origin as the page loading webR. |
+| `PostMessage`               | -- | R code cannot be interrupted. Nested R REPLs, e.g. `browser()`, do not work. |
 
 A communication channel will be automatically selected at startup, defaulting to `SharedArrayBuffer` if the page is cross-origin isolated. It is also possible to manually select a channel type by setting the [`WebROptions.channelType`](api/js/interfaces/WebR.WebROptions.md#channeltype) configuration option at startup.
 
 ::: callout-warning
-Only one JavaScript service worker can be active at at time for a given web page. As such, if you plan to use your own service worker in the web application making use of webR, then you must either use cross-origin isolation and the default `SharedArrayBuffer` communication channel, or integrate the required webR communication message passing into your own service worker.
+Only one JavaScript service worker can be active at at time for a given web page. As such, if you plan to use your own service worker in the web application making use of webR, then you must either use another communication channel, or integrate the required webR communication message passing into your own service worker.
 :::
 
 ## JavaScript promises

--- a/src/docs/serving.qmd
+++ b/src/docs/serving.qmd
@@ -15,6 +15,8 @@ If successful, the value of the global JavaScript property `crossOriginIsolated`
 
 ::: callout-warning
 Without cross-origin isolation, webR will fall back to the [`ServiceWorker`](communication.qmd#webr-channels) communication channel. With this channel there may be reduced performance or [further setup](#sw-cdn) required.
+
+As an alternative, the [`PostMessage`](#postmessage) communication channel may be manually selected for use.
 :::
 
 ## Example script to serve webR pages locally
@@ -39,6 +41,23 @@ runServer(host = "127.0.0.1", port = 8080,
 ```
 
 Run the script on your own machine, for example by executing `Rscript serve.R` in a terminal. Once running, you can access the contents of the current working directory at the URL http://127.0.0.1:8080.
+
+## Using the `PostMessage` channel {#postmessage}
+
+If it is not possible to set the HTTP headers for cross-origin isolation, e.g. you are using an external service such as GitHub Pages to host your web content, the `PostMessage` communication channel may instead be used.
+
+::: callout-warning
+Interruption of running R code and nested R REPLs (`readline()`, `menu()`, `browser()`, etc.) are unsupported when using the `PostMessage` communication channel.
+:::
+
+Enable the `PostMessage` communication channel by explicitly setting [`WebROptions.channelType`](api/js/interfaces/WebR.WebROptions.md#channeltype) during webR initialisation:
+
+``` js
+import { WebR, ChannelType } from 'https://webr.r-wasm.org/latest/webr.mjs';
+const webR = new WebR({
+  channelType: ChannelType.PostMessage,
+});
+```
 
 ## Using the service worker channel when loading from CDN {#sw-cdn}
 

--- a/src/repl/App.tsx
+++ b/src/repl/App.tsx
@@ -91,12 +91,16 @@ root.render(<StrictMode><App /></StrictMode>);
 (async () => {
   await webR.init();
 
-  // Set the default graphics device, pager, and missing package handler
+  // Set the default graphics device and pager
   await webR.evalRVoid('webr::pager_install()');
   await webR.evalRVoid('webr::canvas_install()');
-  await webR.evalRVoid('webr::global_prompt_install()', { withHandlers: false });
 
-  terminalInterface.write('\x1b[2K\r'); // Clear the loading message
+  // If supported, show a menu when prompted for missing package installation
+  const showMenu = crossOriginIsolated || navigator.serviceWorker.controller ? 'TRUE' : 'FALSE';
+  await webR.evalRVoid(`webr::global_prompt_install(${showMenu})`, { withHandlers: false });
+
+  // Clear the loading message
+  terminalInterface.write('\x1b[2K\r');
 
   for (;;) {
     const output = await webR.read();

--- a/src/tests/webR/chan/channel-postmessage.test.ts
+++ b/src/tests/webR/chan/channel-postmessage.test.ts
@@ -1,0 +1,35 @@
+import { WebR } from '../../../webR/webr-main';
+import { Message } from '../../../webR/chan/message';
+import { ChannelType } from '../../../webR/chan/channel-common';
+
+const webR = new WebR({
+  channelType: ChannelType.PostMessage,
+  baseUrl: '../dist/',
+  RArgs: ['--quiet'],
+});
+
+describe('Test communication works with postMessage based channel', () => {
+  test('Initialises successfully', async () => {
+    await expect(webR.init()).resolves.not.toThrow();
+  });
+
+  test('Wait for a prompt', async () => {
+    let msg: Message = await webR.read();
+    while (msg.type !== 'prompt') {
+      msg = await webR.read();
+    }
+    expect(msg.data).toBe('> ');
+  });
+
+  test('Write an R command to the console', () => {
+    expect(() => webR.writeConsole('42\n')).not.toThrow();
+  });
+
+  test('Read result line from stdout', async () => {
+    expect((await webR.read()).data).toBe('[1] 42');
+  });
+});
+
+afterAll(() => {
+  return webR.close();
+});

--- a/src/webR/chan/channel-common.ts
+++ b/src/webR/chan/channel-common.ts
@@ -1,5 +1,6 @@
 import { SharedBufferChannelMain, SharedBufferChannelWorker } from './channel-shared';
 import { ServiceWorkerChannelMain, ServiceWorkerChannelWorker } from './channel-service';
+import { PostMessageChannelMain, PostMessageChannelWorker } from './channel-postmessage';
 import { WebROptions } from '../webr-main';
 import { isCrossOrigin } from '../utils';
 import { WebRChannelError } from '../error';
@@ -12,6 +13,7 @@ export const ChannelType = {
   Automatic: 0,
   SharedArrayBuffer: 1,
   ServiceWorker: 2,
+  PostMessage: 3,
 } as const;
 
 export type ChannelInitMessage = {
@@ -33,6 +35,8 @@ export function newChannelMain(data: Required<WebROptions>) {
       return new SharedBufferChannelMain(data);
     case ChannelType.ServiceWorker:
       return new ServiceWorkerChannelMain(data);
+    case ChannelType.PostMessage:
+      return new PostMessageChannelMain(data);
     case ChannelType.Automatic:
     default:
       if (typeof SharedArrayBuffer !== 'undefined') {
@@ -56,6 +60,8 @@ export function newChannelWorker(msg: ChannelInitMessage) {
       return new SharedBufferChannelWorker();
     case ChannelType.ServiceWorker:
       return new ServiceWorkerChannelWorker(msg.data);
+    case ChannelType.PostMessage:
+      return new PostMessageChannelWorker();
     default:
       throw new WebRChannelError('Unknown worker channel type recieved');
   }

--- a/src/webR/chan/channel-postmessage.ts
+++ b/src/webR/chan/channel-postmessage.ts
@@ -47,7 +47,7 @@ export class PostMessageChannelMain extends ChannelMain {
   }
 
   interrupt() {
-    console.error('Interrupting R execution is not available in PostMessage mode');
+    console.error('Interrupting R execution is not available when using the PostMessage channel');
   }
 
   #handleEventsFromWorker(worker: Worker) {
@@ -140,7 +140,9 @@ export class PostMessageChannelWorker {
   }
 
   read(): Message {
-    throw new Error('Unable to synchronously read from channel in PostMessage mode');
+    throw new WebRChannelError(
+      'Unable to synchronously read when using the `PostMessage` channel.'
+    );
   }
 
   inputOrDispatch(): number {
@@ -151,7 +153,10 @@ export class PostMessageChannelWorker {
     } else if (this.#promptDepth > 0) {
       // For a shallow nested REPL, show an error and try to recover
       // Handles R's `readline()`, `browser()` with an immediate exit
-      console.error('Nested REPL prompts are not available in PostMessage mode');
+      this.writeSystem({
+        type: 'console.error',
+        data: 'Nested REPL prompts are not available when using the `PostMessage` channel.',
+      });
     }
     this.#promptDepth++;
     // Unable to block, so just return a NULL
@@ -171,7 +176,7 @@ export class PostMessageChannelWorker {
 
     this.writeSystem({
       type: 'console.warn',
-      data: 'Running in PostMessage mode. Nested R REPLs are not available.',
+      data: 'WebR is using `PostMessage` communication channel, nested R REPLs are not available.',
     });
 
     Module._Rf_initialize_R(argc, argv);

--- a/src/webR/chan/channel-postmessage.ts
+++ b/src/webR/chan/channel-postmessage.ts
@@ -1,0 +1,264 @@
+import { promiseHandles, ResolveFn, newCrossOriginWorker, isCrossOrigin } from '../utils';
+import { Message, newRequest, Response, Request, newResponse } from './message';
+import { Endpoint } from './task-common';
+import { ChannelType } from './channel-common';
+import { WebROptions } from '../webr-main';
+import { ChannelMain } from './channel';
+import { WebRChannelError } from '../error';
+
+import { IN_NODE } from '../compat';
+import type { Worker as NodeWorker } from 'worker_threads';
+if (IN_NODE) {
+  (globalThis as any).Worker = require('worker_threads').Worker as NodeWorker;
+}
+
+// Main ----------------------------------------------------------------
+
+export class PostMessageChannelMain extends ChannelMain {
+
+  initialised: Promise<unknown>;
+  resolve: (_?: unknown) => void;
+  close = () => {};
+  #worker?: Worker;
+
+  constructor(config: Required<WebROptions>) {
+    super();
+    const initWorker = (worker: Worker) => {
+      this.#worker = worker;
+      this.#handleEventsFromWorker(worker);
+      this.close = () => worker.terminate();
+      const msg = {
+        type: 'init',
+        data: { config, channelType: ChannelType.PostMessage },
+      } as Message;
+      worker.postMessage(msg);
+    };
+
+    if (isCrossOrigin(config.baseUrl)) {
+      newCrossOriginWorker(`${config.baseUrl}webr-worker.js`, (worker: Worker) =>
+        initWorker(worker)
+      );
+    } else {
+      const worker = new Worker(`${config.baseUrl}webr-worker.js`);
+      initWorker(worker);
+    }
+
+    ({ resolve: this.resolve, promise: this.initialised } = promiseHandles());
+  }
+
+  interrupt() {
+    console.error('Interrupting R execution is not available in PostMessage mode');
+  }
+
+  #handleEventsFromWorker(worker: Worker) {
+    if (IN_NODE) {
+      (worker as unknown as NodeWorker).on('message', (message: Message) => {
+        this.#onMessageFromWorker(worker, message);
+      });
+    } else {
+      worker.onmessage = (ev: MessageEvent) =>
+        this.#onMessageFromWorker(worker, ev.data as Message);
+    }
+  }
+
+  #onMessageFromWorker = async (worker: Worker, message: Message) => {
+    if (!message || !message.type) {
+      return;
+    }
+
+    switch (message.type) {
+      case 'resolve':
+        this.resolve();
+        return;
+
+      case 'response':
+        this.resolveResponse(message as Response);
+        return;
+
+      case 'system':
+        this.systemQueue.put(message.data as Message);
+        return;
+
+      default:
+        this.outputQueue.put(message);
+        return;
+
+      case 'request': {
+        const msg = message as Request;
+        const payload = msg.data.msg;
+
+        switch (payload.type) {
+          case 'read': {
+            const input = await this.inputQueue.get();
+            if (this.#worker) {
+              const response = newResponse(msg.data.uuid, input);
+              this.#worker.postMessage(response);
+            }
+            break;
+          }
+          default:
+            throw new WebRChannelError(`Unsupported request type '${payload.type}'.`);
+        }
+        return;
+      }
+
+      case 'sync-request':
+        throw new WebRChannelError(
+          "Can't send messages of type 'sync-request' in PostMessage mode. Use 'request' instead."
+        );
+    }
+  };
+}
+
+// Worker --------------------------------------------------------------
+
+import { Module as _Module } from '../emscripten';
+
+declare let Module: _Module;
+
+export class PostMessageChannelWorker {
+  #ep: Endpoint;
+  #parked = new Map<string, ResolveFn>();
+  #dispatch: (msg: Message) => void = () => 0;
+  #promptDepth = 0;
+  #interrupt = () => {};
+
+  constructor() {
+    this.#ep = (IN_NODE ? require('worker_threads').parentPort : globalThis) as Endpoint;
+  }
+
+  resolve() {
+    this.write({ type: 'resolve' });
+  }
+
+  write(msg: Message, transfer?: [Transferable]) {
+    this.#ep.postMessage(msg, transfer);
+  }
+
+  writeSystem(msg: Message, transfer?: [Transferable]) {
+    this.#ep.postMessage({ type: 'system', data: msg }, transfer);
+  }
+
+  read(): Message {
+    throw new Error('Unable to synchronously read from channel in PostMessage mode');
+  }
+
+  inputOrDispatch(): number {
+    if (this.#promptDepth > 10) {
+      // For a deeply nested REPL, give up and interrupt R evaluation
+      // Avoids an infinite loop with R's `menu()`
+      this.#interrupt();
+    } else if (this.#promptDepth > 0) {
+      // For a shallow nested REPL, show an error and try to recover
+      // Handles R's `readline()`, `browser()` with an immediate exit
+      console.error('Nested REPL prompts are not available in PostMessage mode');
+    }
+    this.#promptDepth++;
+    // Unable to block, so just return a NULL
+    return 0;
+  }
+
+  run(_args: string[]) {
+    const args: string[] = _args || [];
+    args.unshift('R');
+    const argc = args.length;
+    const argv = Module._malloc(4 * (argc + 1));
+    args.forEach((arg, idx) => {
+      const argvPtr = argv + 4 * idx;
+      const argPtr = Module.allocateUTF8(arg);
+      Module.setValue(argvPtr, argPtr, '*');
+    });
+
+    this.writeSystem({
+      type: 'console.warn',
+      data: 'Running in PostMessage mode. Nested R REPLs are not available.',
+    });
+
+    Module._Rf_initialize_R(argc, argv);
+    Module._setup_Rmainloop();
+    Module._R_ReplDLLinit();
+    Module._R_ReplDLLdo1();
+    this.#asyncREPL();
+  }
+
+  setDispatchHandler(dispatch: (msg: Message) => void) {
+    this.#dispatch = dispatch;
+  }
+
+  async request(msg: Message, transferables?: [Transferable]): Promise<any> {
+    const req = newRequest(msg, transferables);
+
+    const { resolve: resolve, promise: prom } = promiseHandles();
+    this.#parked.set(req.data.uuid, resolve);
+
+    this.write(req);
+    return prom;
+  }
+
+  setInterrupt(interrupt: () => void) {
+    this.#interrupt = interrupt;
+  }
+
+  handleInterrupt() {}
+
+  onMessageFromMainThread(message: Message) {
+    const msg = message as Response;
+    const uuid = msg.data.uuid;
+    const resolve = this.#parked.get(uuid);
+
+    if (resolve) {
+      this.#parked.delete(uuid);
+      resolve(msg.data.resp);
+    } else {
+      console.warn("Can't find request.");
+    }
+  }
+
+  /*
+   * This is a fallback REPL for webR running in PostMessage mode. The prompt
+   * section of R's R_ReplDLLdo1 returns empty with -1, which allows this
+   * fallback REPL to yield to the event loop with await.
+   *
+   * The drawback of this approach is that nested REPLs do not work, such as
+   * realine, browser or menu. Attempting to use a nested REPL prints an error
+   * to the JS console.
+   *
+   * R/Wasm errors during execution are caught and the REPL is restarted at the
+   * top level. Any other JS errors are re-thrown.
+   */
+  #asyncREPL = async () => {
+    for (;;) {
+      try {
+        this.#promptDepth = 0;
+        const msg = (await this.request({ type: 'read' })) as Message;
+        if (msg.type === 'stdin') {
+          // Copy the new input into WASM memory
+          const str = Module.allocateUTF8(msg.data as string);
+          Module._strcpy(Module._DLLbuf, str);
+          Module.setValue(Module._DLLbufp, Module._DLLbuf, '*');
+          Module._free(str);
+
+          // Execute the R code using a single step of R's built in REPL
+          try {
+            while (Module._R_ReplDLLdo1() > 0);
+          } catch (e: any) {
+            if (e instanceof (WebAssembly as any).Exception) {
+              // R error: clear command buffer and reproduce prompt
+              Module._R_ReplDLLinit();
+              Module._R_ReplDLLdo1();
+            } else {
+              throw e;
+            }
+          }
+        } else {
+          this.#dispatch(msg);
+        }
+      } catch (e) {
+        // Don't break the REPL loop on any other Wasm issues
+        if (!(e instanceof (WebAssembly as any).Exception)) {
+          throw e;
+        }
+      }
+    }
+  };
+}

--- a/src/webR/chan/channel-shared.ts
+++ b/src/webR/chan/channel-shared.ts
@@ -125,6 +125,7 @@ export class SharedBufferChannelWorker implements ChannelWorker {
   #dispatch: (msg: Message) => void = () => 0;
   #interruptBuffer = new Int32Array(new SharedArrayBuffer(4));
   #interrupt = () => {};
+  onMessageFromMainThread: (msg: Message) => void = () => {};
 
   constructor() {
     this.#ep = (IN_NODE ? require('worker_threads').parentPort : globalThis) as Endpoint;

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -102,6 +102,7 @@ export interface ChannelWorker {
   run(args: string[]): void;
   inputOrDispatch: () => number;
   setDispatchHandler: (dispatch: (msg: Message) => void) => void;
+  onMessageFromMainThread: (msg: Message) => void;
 }
 
 /**

--- a/src/webR/emscripten.ts
+++ b/src/webR/emscripten.ts
@@ -62,6 +62,8 @@ export interface Module extends EmscriptenModule {
   _R_ParseEvalString: (code: number, env: RPtr) => RPtr;
   _R_PreserveObject: (ptr: RPtr) => void;
   _R_ReleaseObject: (ptr: RPtr) => void;
+  _R_ReplDLLinit: () => void;
+  _R_ReplDLLdo1: () => number;
   _Rf_ScalarReal: (n: number) => RPtr;
   _Rf_ScalarLogical: (l: number) => RPtr;
   _Rf_ScalarInteger: (n: number) => RPtr;
@@ -74,6 +76,7 @@ export interface Module extends EmscriptenModule {
   _Rf_findVarInFrame: (rho: RPtr, symbol: RPtr) => RPtr;
   _Rf_listAppend: (source: RPtr, target: RPtr) => RPtr;
   _Rf_getAttrib: (ptr1: RPtr, ptr2: RPtr) => RPtr;
+  _Rf_initialize_R: (argc: number, argv: RPtr) => void;
   _Rf_install: (ptr: number) => RPtr;
   _Rf_installTrChar: (name: RPtr) => RPtr;
   _Rf_lang1: (ptr1: RPtr) => RPtr;
@@ -92,6 +95,8 @@ export interface Module extends EmscriptenModule {
   _Rf_setAttrib: (ptr1: RPtr, ptr2: RPtr, ptr3: RPtr) => RPtr;
   _Rf_unprotect: (n: number) => void;
   _Rf_unprotect_ptr: (ptr: RPtr) => void;
+  _DLLbuf: RPtr;
+  _DLLbufp: RPtr;
   _R_BaseEnv: RPtr;
   _R_BracketSymbol: RPtr;
   _R_Bracket2Symbol: RPtr;
@@ -110,6 +115,8 @@ export interface Module extends EmscriptenModule {
   _R_UnboundValue: RPtr;
   _SET_STRING_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;
   _SET_VECTOR_ELT: (ptr: RPtr, idx: number, val: RPtr) => void;
+  _setup_Rmainloop: () => void;
+  _strcpy: (dest: RPtr, src: RPtr) => number;
   // TODO: Namespace all webR properties
   webr: {
     UnwindProtectException: typeof UnwindProtectException;

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -35,6 +35,7 @@ import {
 export { Console, ConsoleCallbacks } from './console';
 export * from './robj-main';
 export * from './error';
+export { ChannelType } from './chan/channel-common';
 
 /**
  * The webR FS API for interacting with the Emscripten Virtual File System.

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -33,16 +33,20 @@ let initialised = false;
 let chan: ChannelWorker | undefined;
 
 const onWorkerMessage = function (msg: Message) {
-  if (!msg || !msg.type || msg.type !== 'init') {
+  if (!msg || !msg.type) {
     return;
   }
-  if (initialised) {
-    throw new Error("Can't initialise worker multiple times.");
+  if (msg.type === 'init') {
+    if (initialised) {
+      throw new Error("Can't initialise worker multiple times.");
+    }
+    const messageInit = msg as ChannelInitMessage;
+    chan = newChannelWorker(messageInit);
+    init(messageInit.data.config);
+    initialised = true;
+    return;
   }
-  const messageInit = msg as ChannelInitMessage;
-  chan = newChannelWorker(messageInit);
-  init(messageInit.data.config);
-  initialised = true;
+  chan?.onMessageFromMainThread(msg);
 };
 
 if (IN_NODE) {


### PR DESCRIPTION
When we released webR 0.1.0, we decided to avoid adding a communication channel based on JS `postMessage`, because such a method would rely on yielding to the event loop, which is incompatible with blocking in Wasm. Ultimately, blocking in Wasm is required for nested REPLs (`menu()`, `readline()`, `browser()`, and maybe others).

As a reminder, in the current setup webR will block with `Atomics` using `SharedArrayBuffer` if the page is Cross-Origin Isolated (COI). Otherwise, webR will fall back to using a webR Service Worker (SW) script to block the worker thread.

Requiring COI for `SharedArrayBuffer` communication has a few drawbacks,
* Loading cross-origin content can be difficult (e.g. externally hosted data or JS tools/frameworks).
* Web pages embedding a COI page through an iframe must themselves also be COI.
* Not all services allow setting the HTTP headers for COI, such as GitHub Pages.

The webR Service Worker method also has a few drawbacks:
* A significant performance impact, particularly when loading packages.
* The webR service worker fallback is fiddly to set up, requiring `webr-serviceworker.js` to be served at the root of the app.
* Only one service worker can be active for a given origin at a time. 

In addition, I have been working on integrating webR with Shinylive and have the following observations:

* The Service Worker fallback cannot be used (Shinylive already has its own service worker), so we are forced to use COI.
* Forcing COI in Shinylive requires a hack in the Shinylive Service Worker to inject the COI HTTP headers:
  - Some browsers don't work: e.g. VS Code built-in web browser
  - It breaks Shinylive for Python - but we need both R and Python Shiny apps into a single Quarto output web page.
* It is unlikely that a Shinylive end user will require `readline()` or `browser()`. Perhaps useful during debugging.
* The final output doesn't require an R console, just the Shiny client.

I think the time has come to reconsider adding a reduced-functionality `postMessage` fallback. In this communication channel, a custom asynchronous REPL is used, based on internal R functions, which allows the worker thread to yield to the event loop at the top level.

The channel is opt-in, requiring `channelType: ChannelType.PostMessage` in `WebROptions`.

Downsides: Deeper nested REPLs won't work. Long-running R code cannot be interrupted.

Other notes: When loading missing packages, we cannot show a "Yes/No" menu, so this PR also adds functionality so that missing packages are automatically downloaded when using the fallback channel.
