### PR TITLE
Fallback to the `PostMessage` channel when using `ChannelType.Automatic`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
 
 * Expose Emscripten's `FS.mount()` on `webr::mount` in R, and `webR.FS.mount()` in JavaScript. This allows images built using Emscripten's `file_packager` to be mounted on the virtual filesystem and host directory paths to be mounted when running under Node.
 
+## Breaking changes
+
+* When starting webR using the `ChannelType.Automatic` channel (the default), the `PostMessage` channel is now used as the fallback when the web page is not Cross-Origin Isolated. The `PostMessage` channel has the widest compatibility, but is unable to use functions that block for input (e.g. `readline()`, `menu()`, `browser()`, etc). If blocking for input is required, the `ServiceWorker` channel is still available, but must be requested explicitly.
+
 # webR 0.2.1
 
 ## New features

--- a/src/webR/chan/channel-common.ts
+++ b/src/webR/chan/channel-common.ts
@@ -2,7 +2,6 @@ import { SharedBufferChannelMain, SharedBufferChannelWorker } from './channel-sh
 import { ServiceWorkerChannelMain, ServiceWorkerChannelWorker } from './channel-service';
 import { PostMessageChannelMain, PostMessageChannelWorker } from './channel-postmessage';
 import { WebROptions } from '../webr-main';
-import { isCrossOrigin } from '../utils';
 import { WebRChannelError } from '../error';
 
 // This file refers to objects imported from `./channel-shared` and
@@ -41,16 +40,9 @@ export function newChannelMain(data: Required<WebROptions>) {
     default:
       if (typeof SharedArrayBuffer !== 'undefined') {
         return new SharedBufferChannelMain(data);
+      } else {
+        return new PostMessageChannelMain(data);
       }
-      /*
-       * TODO: If we are not cross-origin isolated but we can still use service
-       * workers, we could setup a service worker to inject the relevant headers
-       * to enable cross-origin isolation.
-       */
-      if ('serviceWorker' in navigator && !isCrossOrigin(data.serviceWorkerUrl)) {
-        return new ServiceWorkerChannelMain(data);
-      }
-      throw new WebRChannelError("Can't initialise main thread communication channel");
   }
 }
 


### PR DESCRIPTION
With this change, when using `ChannelType.Automatic` channel (the default), the `PostMessage` channel is used as the fallback when the web page is not Cross-Origin Isolated, replacing `ServiceWorker`.

The `PostMessage` channel has the widest compatibility, but is unable to block for input (e.g. `readline()`, `menu()`, `browser()`, etc). 

After the introduction of the `PostMessage` channel for use with Shinylive, the response has been positive from other users too, praising the wider compatibility with static web servers. After discussion with @wch and under [suggestion](https://github.com/coatless/quarto-webr/issues/31#issuecomment-1720961696) from @coatless, I think it makes sense for `PostMessage` to be the default fallback position for automatic mode:

1) The previous `ServiceWorker` fallback was never really "automatic", it required extra setup in terms of placing special files on the server.
2) Before or after the change, we have the situation where there is some kind of reduced functionality when the page is not COI, but adding COI headers enables the extra functionality. This seems reasonable to me.

Note that this is a breaking change. If blocking for input is required, and COI is not possible, the `ServiceWorker` channel is still available as an alternative, but the user code that loads webR must be changed to request it explicitly.

(P.S. If the `ServiceWorker` channel turns out to be rarely used after this change, we could consider deprecation. My impression is that the performance impact and other issues (#261) with this channel make it rarely useful, particularly when loading R packages.)