### PR TITLE
Raise R error conditions on `system()` and when unable to block for input.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,10 @@
 
 * When starting webR using the `ChannelType.Automatic` channel (the default), the `PostMessage` channel is now used as the fallback when the web page is not Cross-Origin Isolated. The `PostMessage` channel has the widest compatibility, but is unable to use functions that block for input (e.g. `readline()`, `menu()`, `browser()`, etc). If blocking for input is required, the `ServiceWorker` channel is still available, but must be requested explicitly.
 
+* Invoking the `system()` function now raises an R error condition.
+
+* Invoking functions that block for input now raises an R error condition when running under the `PostMessage` communication channel.
+
 # webR 0.2.1
 
 ## New features

--- a/packages/webr/R/testing.R
+++ b/packages/webr/R/testing.R
@@ -64,6 +64,8 @@ remove_lines_in_file <- function(src_file, lines) {
 #' @param pkg Name of the package to test.
 #' @returns 0 if the test was successful, otherwise 1.
 test_package <- function(pkg) {
+  op <- options(webr.hook_system = function(...) c("", ""))
+  on.exit(options(op), add = TRUE)
   old_wd <- getwd()
   pkgdir <- find.package(pkg)
 

--- a/packages/webr/inst/tests-webr/test-webr.R
+++ b/packages/webr/inst/tests-webr/test-webr.R
@@ -1,9 +1,13 @@
 "System calls are intercepted"
 webr:::sandbox({
-  # Default return value
+  # Default error condition
+  err_cond <- tools::assertError(system("cmd"))
   stopifnot(
-    identical(system("cmd"), c("", "")),
-    identical(system2("cmd"), c("", ""))
+    grepl("unsupported under Emscripten", conditionMessage(err_cond[[1]]))
+  )
+  err_cond <- tools::assertError(system2("cmd"))
+  stopifnot(
+    grepl("unsupported under Emscripten", conditionMessage(err_cond[[1]]))
   )
 
   # Hooked

--- a/patches/R-4.3.0/emscripten-disable-system.diff
+++ b/patches/R-4.3.0/emscripten-disable-system.diff
@@ -1,7 +1,7 @@
-Index: R-4.2.2/src/library/base/R/unix/system.unix.R
+Index: R-4.3.0/src/library/base/R/unix/system.unix.R
 ===================================================================
---- R-4.2.2.orig/src/library/base/R/unix/system.unix.R
-+++ R-4.2.2/src/library/base/R/unix/system.unix.R
+--- R-4.3.0.orig/src/library/base/R/unix/system.unix.R
++++ R-4.3.0/src/library/base/R/unix/system.unix.R
 @@ -35,6 +35,11 @@ system <- function(command, intern = FALSE,
      if(!is.logical(wait) || is.na(wait))
          stop("'wait' must be TRUE or FALSE")
@@ -26,21 +26,41 @@ Index: R-4.2.2/src/library/base/R/unix/system.unix.R
      intern <- FALSE
      command <- paste(c(env, shQuote(command), args), collapse = " ")
  
-@@ -105,6 +115,17 @@ system2 <- function(command, args = character(),
-     } else if (nzchar(stdin)) command <- paste(command, "<", shQuote(stdin))
-     if(!wait && !intern) command <- paste(command, "&")
+@@ -107,13 +117,23 @@ system2 <- function(command, args = character(),
      .Internal(system(command, intern, timeout))
-+}
-+
+ }
+ 
 +webr_hook_system <- function(command) {
 +    hook <- getOption("webr.hook_system")
 +    if (is.function(hook)) {
-+       # This hook may be used to e.g. call `testthat::skip()`
-+	hook(command)
++        # This hook may be used to e.g. call `testthat::skip()`
++        hook(command)
 +    } else {
-+       # Try to carry on regardless, as if it had worked but produced no output
-+	c("", "")
++        stop("The `system()` function is unsupported under Emscripten.")
 +    }
- }
- 
++}
++
  ## Some people try to use this with NA inputs (PR#15147)
+ Sys.which <- function(names)
+ {
+     res <- character(length(names)); names(res) <- names
+     ## hopefully configure found [/usr]/bin/which
+     which <- "@WHICH@"
+-    if (!nzchar(which)) {
++    if (!nzchar(which) || grepl("emscripten", R.version$os)) {
+         warning("'which' was not found on this platform")
+         return(res)
+     }
+Index: R-4.3.0/src/library/utils/R/sessionInfo.R
+===================================================================
+--- R-4.3.0.orig/src/library/utils/R/sessionInfo.R
++++ R-4.3.0/src/library/utils/R/sessionInfo.R
+@@ -23,6 +23,8 @@
+     ## Now try to figure out the OS we are running under
+     if (.Platform$OS.type == "windows") {
+         win.version()
++    } else if (grepl("emscripten", R.version$os)) {
++        "emscripten"
+     } else if (nzchar(Sys.which('uname'))) { ## we could try /usr/bin/uname
+         uname <- system("uname -a", intern = TRUE)
+         os <- sub(" .*", "", uname)


### PR DESCRIPTION
Includes minor tweaks to `Sys.which` and `sessionInfo` to avoid using `system()` when running under Emscripten.

Closes #279.