### PR TITLE
Install R packages using Emscripten's filesystem mounting API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Expose Emscripten's `FS.mount()` on `webr::mount` in R, and `webR.FS.mount()` in JavaScript. This allows images built using Emscripten's `file_packager` to be mounted on the virtual filesystem and host directory paths to be mounted when running under Node.
 
+* By default, `webr::install()` now uses `webr::mount()` to mount Wasm R packages into the R library, rather than downloading package `.tgz` archives and decompressing the contents to the virtual filesystem. This improves the performance of package installation. If the package repository does not provide `.data` Emscripten filesystem images, `webr::install()` will fallback to downloading `.tgz` packages, as before.
+
 ## Breaking changes
 
 * When starting webR using the `ChannelType.Automatic` channel (the default), the `PostMessage` channel is now used as the fallback when the web page is not Cross-Origin Isolated. The `PostMessage` channel has the widest compatibility, but is unable to use functions that block for input (e.g. `readline()`, `menu()`, `browser()`, etc). If blocking for input is required, the `ServiceWorker` channel is still available, but must be requested explicitly.

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 * Invoking functions that block for input now raises an R error condition when running under the `PostMessage` communication channel.
 
+* Options are now passed to the JavaScript function `webR.installPackages()` in the form of an `options` argument, an object of type `InstallPackagesOptions`.
+
 ## Bug fixes
 
 * Certain graphical properties, e.g `lty` & `lwd`, now work correctly in the webR `canvas()` graphics device. (#289, #304).

--- a/packages/webr/R/canvas.R
+++ b/packages/webr/R/canvas.R
@@ -35,7 +35,11 @@
 #' @param pointsize	The default point size of plotted text.
 #' @param bg The initial background colour.
 #' @param ... Additional graphics device arguments (ignored).
-canvas <- function(width=504, height=504, pointsize=12, bg="transparent", ...) {
+canvas <- function(width = 504,
+                   height = 504,
+                   pointsize = 12,
+                   bg = "transparent",
+                   ...) {
   .Call(ffi_dev_canvas, width, height, pointsize, bg)
 }
 
@@ -47,5 +51,7 @@ canvas <- function(width=504, height=504, pointsize=12, bg="transparent", ...) {
 #' @param ... Arguments to be passed to the graphics device.
 #' @export
 canvas_install <- function(...) {
-  options(device = function() { webr::canvas(...) })
+  options(device = function() {
+    webr::canvas(...)
+  })
 }

--- a/packages/webr/R/install.R
+++ b/packages/webr/R/install.R
@@ -5,8 +5,11 @@
 #' @param packages Character vector containing the names of packages to install.
 #' @param repos Character vector containing the URIs of the webR repos to use.
 #' @param lib The library directory where the packages will be installed.
+#' @param mount Logical. If `TRUE`, download and mount packages using Emscripten
+#'   filesystem images.
 #' @param quiet Logical. If `TRUE`, do not output downloading messages.
-install <- function(packages, repos = NULL, lib = NULL, quiet = FALSE) {
+install <- function(packages, repos = NULL, lib = NULL, quiet = FALSE,
+                    mount = TRUE) {
   if (is.null(lib)) {
     lib <- .libPaths()[[1]]
   }
@@ -27,7 +30,7 @@ install <- function(packages, repos = NULL, lib = NULL, quiet = FALSE) {
     if (length(find.package(dep, quiet = TRUE))) {
       next
     }
-    install(dep, repos, lib, quiet)
+    install(dep, repos, lib, quiet, mount)
   }
 
   for (pkg in packages) {
@@ -44,18 +47,42 @@ install <- function(packages, repos = NULL, lib = NULL, quiet = FALSE) {
     repo <- sub("file:", "", repo, fixed = TRUE)
 
     pkg_ver <- info[pkg, "Version"]
-    path <- file.path(repo, paste0(pkg, "_", pkg_ver, ".tgz"))
-
-    tmp <- tempfile()
+    pkg_ver <- info[pkg, "Version"]
     if (!quiet) message(paste("Downloading webR package:", pkg))
-    utils::download.file(path, tmp, quiet = TRUE)
 
-    utils::untar(
-      tmp,
-      exdir = lib,
-      tar = "internal",
-      extras = "--no-same-permissions"
-    )
+    if (mount) {
+      # Try package.data URL, fallback to .tgz download if unavailable
+      tryCatch({
+        install_vfs_image(repo, lib, pkg, pkg_ver)
+      }, error = function(cnd) {
+        if (!grepl("Unable to download", conditionMessage(cnd))) {
+          stop(cnd)
+        }
+        install_tgz(repo, lib, pkg, pkg_ver)
+      })
+    } else {
+      install_tgz(repo, lib, pkg, pkg_ver)
+    }
   }
   invisible(NULL)
+}
+
+install_tgz <- function(repo, lib, pkg, pkg_ver) {
+  tmp <- tempfile()
+  on.exit(unlink(tmp, recursive = TRUE))
+
+  path <- file.path(repo, paste0(pkg, "_", pkg_ver, ".tgz"))
+  utils::download.file(path, tmp, quiet = TRUE)
+  utils::untar(
+    tmp,
+    exdir = lib,
+    tar = "internal",
+    extras = "--no-same-permissions"
+  )
+}
+
+install_vfs_image <- function(repo, lib, pkg, pkg_ver) {
+  data_url <- file.path(repo, paste0(pkg, "_", pkg_ver, ".data"))
+  mountpoint <- file.path(lib, pkg)
+  mount(mountpoint, data_url)
 }

--- a/packages/webr/R/install.R
+++ b/packages/webr/R/install.R
@@ -54,7 +54,6 @@ install <- function(packages, repos = NULL, info = NULL, lib = NULL,
     repo <- sub("file:", "", repo, fixed = TRUE)
 
     pkg_ver <- info[pkg, "Version"]
-    pkg_ver <- info[pkg, "Version"]
     if (!quiet) message(paste("Downloading webR package:", pkg))
 
     if (mount) {

--- a/packages/webr/R/install.R
+++ b/packages/webr/R/install.R
@@ -10,8 +10,12 @@
 #' @param mount Logical. If `TRUE`, download and mount packages using Emscripten
 #'   filesystem images.
 #' @param quiet Logical. If `TRUE`, do not output downloading messages.
-install <- function(packages, repos = NULL, info = NULL, lib = NULL,
-                    quiet = FALSE, mount = TRUE) {
+install <- function(packages,
+                    repos = NULL,
+                    info = NULL,
+                    lib = NULL,
+                    quiet = FALSE,
+                    mount = TRUE) {
   if (is.null(lib)) {
     lib <- .libPaths()[[1]]
   }
@@ -58,14 +62,17 @@ install <- function(packages, repos = NULL, info = NULL, lib = NULL,
 
     if (mount) {
       # Try package.data URL, fallback to .tgz download if unavailable
-      tryCatch({
-        install_vfs_image(repo, lib, pkg, pkg_ver)
-      }, error = function(cnd) {
-        if (!grepl("Unable to download", conditionMessage(cnd))) {
-          stop(cnd)
+      tryCatch(
+        {
+          install_vfs_image(repo, lib, pkg, pkg_ver)
+        },
+        error = function(cnd) {
+          if (!grepl("Unable to download", conditionMessage(cnd))) {
+            stop(cnd)
+          }
+          install_tgz(repo, lib, pkg, pkg_ver)
         }
-        install_tgz(repo, lib, pkg, pkg_ver)
-      })
+      )
     } else {
       install_tgz(repo, lib, pkg, pkg_ver)
     }

--- a/packages/webr/R/mount.R
+++ b/packages/webr/R/mount.R
@@ -1,21 +1,21 @@
 #' Mount an Emscripten filesystem object
-#' 
+#'
 #' @description
 #' Uses the Emscripten filesystem API to mount a filesystem object onto a given
 #' directory in the virtual filesystem. The mountpoint will be created if it
 #' does not already exist.
-#' 
+#'
 #' When mounting an Emscripten "workerfs" type filesystem the `source` should
 #' be the URL for a filesystem image with filename ending `.data`, as produced
 #' by Emscripten's `file_packager` tool. The filesystem image and metadata will
 #' be downloaded and mounted onto the directory `mountpoint`.
-#' 
+#'
 #' When mounting an Emscripten "nodefs" type filesystem, the `source` should be
 #' the path to a physical directory on the host filesystem. The host directory
 #' will be mapped into the virtual filesystem and mounted onto the directory
 #' `mountpoint`. This filesystem type can only be used when webR is running
 #' under Node.
-#' 
+#'
 #' @param mountpoint a character string giving the path to a directory to mount
 #'   onto in the Emscripten virtual filesystem.
 #' @param source a character string giving the location of the data source to be
@@ -27,7 +27,7 @@
 mount <- function(mountpoint, source, type = "workerfs") {
   # Create the mountpoint if it does not already exist
   dir.create(mountpoint, recursive = TRUE, showWarnings = FALSE)
-  
+
   # Mount specified Emscripten filesystem type onto the given mountpoint
   if (tolower(type) == "workerfs") {
     base_url <- gsub(".data$", "", source)

--- a/packages/webr/R/shims.R
+++ b/packages/webr/R/shims.R
@@ -9,9 +9,8 @@
 #' - install.packages() - replaced by webr::install().
 #'
 #' @export
-shim_install <- function(){
+shim_install <- function() {
   .e <- new.env()
   .e[["install.packages"]] <- webr::install
   attach(.e, name = "webr_shims", warn.conflicts = FALSE)
 }
-

--- a/packages/webr/man/install.Rd
+++ b/packages/webr/man/install.Rd
@@ -4,7 +4,7 @@
 \alias{install}
 \title{Install one or more packages from a webR binary package repo}
 \usage{
-install(packages, repos = NULL, lib = NULL, quiet = FALSE)
+install(packages, repos = NULL, lib = NULL, quiet = FALSE, mount = TRUE)
 }
 \arguments{
 \item{packages}{Character vector containing the names of packages to install.}
@@ -14,6 +14,9 @@ install(packages, repos = NULL, lib = NULL, quiet = FALSE)
 \item{lib}{The library directory where the packages will be installed.}
 
 \item{quiet}{Logical. If \code{TRUE}, do not output downloading messages.}
+
+\item{mount}{Logical. If \code{TRUE}, download and mount packages using Emscripten
+filesystem images.}
 }
 \description{
 Install one or more packages from a webR binary package repo

--- a/src/tests/packages/webr.test.ts
+++ b/src/tests/packages/webr.test.ts
@@ -14,7 +14,7 @@ async function evalTest(pkg: string) {
 beforeAll(async () => {
   await webR.init();
   // Install packages required to run all package examples and tests
-  await webR.installPackages(['Matrix', 'MASS'], true);
+  await webR.installPackages(['Matrix', 'MASS'], { quiet: true, mount: false });
 });
 
 test('The webr R package is installed', async () => {

--- a/src/tests/webR/webr-worker.test.ts
+++ b/src/tests/webR/webr-worker.test.ts
@@ -16,7 +16,9 @@ beforeAll(async () => {
 describe('Download and install binary webR packages', () => {
   test('Install packages via evalR', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation((...args) => {});
-    await webR.evalR('webr::install("cli", repos="https://repo.r-wasm.org/")');
+    await webR.evalR(
+      'webr::install("cli", repos="https://repo.r-wasm.org/", mount = FALSE)'
+    );
     const pkg = (await webR.evalR('"cli" %in% library(cli)')) as RLogical;
     expect(await pkg.toBoolean()).toEqual(true);
     warnSpy.mockRestore();
@@ -24,14 +26,16 @@ describe('Download and install binary webR packages', () => {
 
   test('Install packages quietly', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation((...args) => {});
-    await webR.evalR('webr::install("Matrix", repos="https://repo.r-wasm.org/", quiet=TRUE)');
+    await webR.evalR(
+      'webr::install("Matrix", repos="https://repo.r-wasm.org/", mount = FALSE, quiet = TRUE)'
+    );
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
 
   test('Install packages via API', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation((...args) => {});
-    await webR.installPackages(['MASS']);
+    await webR.installPackages(['MASS'], { mount: false });
     const pkg = (await webR.evalR('"MASS" %in% library(MASS)')) as RLogical;
     expect(await pkg.toBoolean()).toEqual(true);
     warnSpy.mockRestore();

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -22,6 +22,36 @@ export interface CallRObjectMethodMessage extends Message {
 }
 
 /**
+ * The configuration settings used when installing R packages.
+ */
+export interface InstallPackagesOptions {
+  /**
+   * The R package repository from which to download packages.
+   * Default: The configured default webR package repository.
+   */
+  repos?: string;
+  /**
+   * If `true`, do not output downloading messages.
+   * Default: `false`.
+   */
+  quiet?: boolean;
+  /**
+   * If `true`, attempt to mount packages using filesystem images.
+   * Default: `true`.
+   */
+  mount?: boolean;
+}
+
+/** @internal */
+export interface InstallPackagesMessage extends Message {
+  type: 'installPackage';
+  data: {
+    name: string;
+    options: InstallPackagesOptions;
+  };
+}
+
+/**
  * The configuration settings used when evaluating R code.
  */
 export interface EvalROptions {

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -360,10 +360,11 @@ export class WebR {
    * Install a list of R packages from the default webR CRAN-like repo.
    * @param {string[]} packages An array of R pacakge names.
    * @param {boolean} quiet If true, do not output downloading messages.
+   * @param {boolean} mount If true, attempt to mount packages using filesystem images.
    */
-  async installPackages(packages: string[], quiet = false) {
+  async installPackages(packages: string[], quiet = false, mount = true) {
     for (const name of packages) {
-      const msg = { type: 'installPackage', data: { name, quiet } };
+      const msg = { type: 'installPackage', data: { name, quiet, mount } };
       await this.#chan.request(msg);
     }
   }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -358,7 +358,7 @@ export class WebR {
   }
 
   /**
-   * Install a list of R packages from a webR binary pack repo.
+   * Install a list of R packages from a Wasm binary package repo.
    * @param {string[]} packages An array of R package names.
    * @param {InstallPackagesOptions} [options] Options to be used when
    *   installing webR packages.

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -27,6 +27,7 @@ import {
   FSMountMessage,
   FSReadFileMessage,
   FSWriteFileMessage,
+  InstallPackagesOptions,
   InvokeWasmFunctionMessage,
   NewShelterMessage,
   ShelterDestroyMessage,
@@ -357,14 +358,19 @@ export class WebR {
   }
 
   /**
-   * Install a list of R packages from the default webR CRAN-like repo.
-   * @param {string[]} packages An array of R pacakge names.
-   * @param {boolean} quiet If true, do not output downloading messages.
-   * @param {boolean} mount If true, attempt to mount packages using filesystem images.
+   * Install a list of R packages from a webR binary pack repo.
+   * @param {string[]} packages An array of R package names.
+   * @param {InstallPackagesOptions} [options] Options to be used when
+   *   installing webR packages.
    */
-  async installPackages(packages: string[], quiet = false, mount = true) {
+  async installPackages(packages: string[], options?: InstallPackagesOptions) {
+    const op = Object.assign({
+      quiet: false,
+      mount: true
+    }, options);
+
     for (const name of packages) {
-      const msg = { type: 'installPackage', data: { name, quiet, mount } };
+      const msg = { type: 'installPackage', data: { name, options: op } };
       await this.#chan.request(msg);
     }
   }

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -411,7 +411,8 @@ function dispatch(msg: Message): void {
             evalR(`webr::install(
               "${reqMsg.data.name as string}",
               repos = "${_config.repoUrl}",
-              quiet = ${reqMsg.data.quiet ? 'TRUE' : 'FALSE'}
+              quiet = ${reqMsg.data.quiet ? 'TRUE' : 'FALSE'},
+              mount = ${reqMsg.data.mount ? 'TRUE' : 'FALSE'}
             )`);
 
             write({

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -28,6 +28,7 @@ import {
   NewRObjectMessage,
   ShelterMessage,
   ShelterDestroyMessage,
+  InstallPackagesMessage,
 } from './webr-chan';
 
 let initialised = false;
@@ -408,11 +409,12 @@ function dispatch(msg: Message): void {
           }
 
           case 'installPackage': {
+            const msg = reqMsg as InstallPackagesMessage;
             evalR(`webr::install(
-              "${reqMsg.data.name as string}",
-              repos = "${_config.repoUrl}",
-              quiet = ${reqMsg.data.quiet ? 'TRUE' : 'FALSE'},
-              mount = ${reqMsg.data.mount ? 'TRUE' : 'FALSE'}
+              "${msg.data.name}",
+              repos = "${msg.data.options.repos ? msg.data.options.repos : _config.repoUrl}",
+              quiet = ${msg.data.options.quiet ? 'TRUE' : 'FALSE'},
+              mount = ${msg.data.options.mount ? 'TRUE' : 'FALSE'}
             )`);
 
             write({


### PR DESCRIPTION
With this set of changes, when installing an R package webR will first check for the existence of `package_version.data` files in the CRAN-like repo. These files should be Emscripten filesystem images. If they exist, they are downloaded and mounted using the Emscripten filesystem API. Otherwise, there is a fallback to the previous method of downloading and extracting `.tgz` files.

When mounting, the step where R package contents are decompressed and written to the virtual filesystem is not required. The Emscripten filesystem API instead creates nodes on the virtual filesystem that directly reference slices of the `ArrayBuffer` containing the downloaded data. This makes loading R packages quicker and more efficient (particularly when previously downloaded package files are cached).

The cost is a larger package since the `package_version.data` files are uncompressed. However, this is not too much of a worry since the files can be compressed over the wire as the user's browser and the static webserver negotiate a compression protocol using the [`Content-Encoding`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) mechanism. If it is a real worry for certain applications, the `.tgz` fallback can be used to serve compressed packages.

Comparison on my machine when loading `{tidyverse}` and its dependencies:

Version | Fresh Download | Cached  |
--- | ------------- | ------------- |
v0.2.1 | 80 seconds  |  59.4 seconds |
dev    |  19.6 seconds | 2.9 seconds |