### PR TITLE
update libjpeg to fix missing .pc file

### DIFF
--- a/libs/recipes/jpeg/rules.mk
+++ b/libs/recipes/jpeg/rules.mk
@@ -1,4 +1,4 @@
-LIBJPEG_VERSION = 9b
+LIBJPEG_VERSION = 9e
 LIBJPEG_TARBALL = $(DOWNLOAD)/libjpeg-$(LIBJPEG_VERSION).tar.gz
 LIBJPEG_URL = http://www.ijg.org/files/jpegsrc.v$(LIBJPEG_VERSION).tar.gz
 


### PR DESCRIPTION
The `ragg` package currently cannot be built because it cannot find libjpeg. It turns out `libjpeg.pc` is missing. Updating libjpeg seems to resolve the problem.

