### PR TITLE
Add gmp, mpfr, glpk

### DIFF
--- a/libs/recipes/glpk/rules.mk
+++ b/libs/recipes/glpk/rules.mk
@@ -1,0 +1,22 @@
+GLPK_VERSION = 5.0
+GLPK_TARBALL = $(DOWNLOAD)/glpk-$(GLPK_VERSION).tar.gz
+GLPK_URL = https://ftp.gnu.org/gnu/glpk/glpk-$(GLPK_VERSION).tar.gz
+
+.PHONY: glpk
+glpk: $(GLPK_WASM_LIB)
+
+$(GLPK_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget $(GLPK_URL) -O $@
+
+$(GLPK_WASM_LIB): $(GLPK_TARBALL) $(GMP_WASM_LIB)
+	mkdir -p $(BUILD)/glpk-$(GLPK_VERSION)/build
+	tar -C $(BUILD) -xf $(GLPK_TARBALL)
+	cd $(BUILD)/glpk-$(GLPK_VERSION)/build && \
+	  emconfigure ../configure \
+	    --with-gmp \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --prefix=$(WASM) && \
+	  emmake make install
+

--- a/libs/recipes/glpk/targets.mk
+++ b/libs/recipes/glpk/targets.mk
@@ -1,0 +1,2 @@
+GLPK_WASM_LIB = $(WASM)/lib/libglpk.a
+OPTIONAL_WASM_LIBS += $(GLPK_WASM_LIB)

--- a/libs/recipes/gmp/rules.mk
+++ b/libs/recipes/gmp/rules.mk
@@ -1,0 +1,25 @@
+GMP_VERSION = 6.3.0
+GMP_TARBALL = $(DOWNLOAD)/gmp-$(GMP_VERSION).tar.gz
+GMP_URL = https://ftp.gnu.org/gnu/gmp/gmp-$(GMP_VERSION).tar.xz
+
+.PHONY: gmp
+gmp: $(GMP_WASM_LIB)
+
+$(GMP_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget $(GMP_URL) -O $@
+
+$(GMP_WASM_LIB): $(GMP_TARBALL)
+	mkdir -p $(BUILD)/gmp-$(GMP_VERSION)/build
+	tar -C $(BUILD) -xf $(GMP_TARBALL)
+	cd $(BUILD)/gmp-$(GMP_VERSION)/build && \
+	  emconfigure ../configure \
+	    --build=x86_64-pc-linux-gnu \
+	    --host=wasm32-unknown-emscripten \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --disable-assembly \
+	    --enable-cxx \
+	    --prefix=$(WASM) && \
+	  emmake make install
+

--- a/libs/recipes/gmp/rules.mk
+++ b/libs/recipes/gmp/rules.mk
@@ -2,6 +2,13 @@ GMP_VERSION = 6.3.0
 GMP_TARBALL = $(DOWNLOAD)/gmp-$(GMP_VERSION).tar.gz
 GMP_URL = https://ftp.gnu.org/gnu/gmp/gmp-$(GMP_VERSION).tar.xz
 
+# Cross-compile fix for Emscripten-on-macOS
+UNAME := $(shell uname)
+ifeq ($(UNAME),Darwin)
+	HOST_CFLAGS += "-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include"
+	HOST_CFLAGS += "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+endif
+
 .PHONY: gmp
 gmp: $(GMP_WASM_LIB)
 
@@ -13,13 +20,14 @@ $(GMP_WASM_LIB): $(GMP_TARBALL)
 	mkdir -p $(BUILD)/gmp-$(GMP_VERSION)/build
 	tar -C $(BUILD) -xf $(GMP_TARBALL)
 	cd $(BUILD)/gmp-$(GMP_VERSION)/build && \
-	  emconfigure ../configure \
-	    --build=x86_64-pc-linux-gnu \
-	    --host=wasm32-unknown-emscripten \
-	    --enable-shared=no \
-	    --enable-static=yes \
-	    --disable-assembly \
-	    --enable-cxx \
-	    --prefix=$(WASM) && \
+	    emconfigure bash -c '\
+	      HOST_CC="$${HOST_CC} $(HOST_CFLAGS)" ../configure \
+	      --host=wasm32-unknown-emscripten \
+	      --enable-shared=no \
+	      --enable-static=yes \
+	      --disable-assembly \
+	      --enable-cxx \
+	      --prefix=$(WASM) \
+	    ' && \
 	  emmake make install
 

--- a/libs/recipes/gmp/targets.mk
+++ b/libs/recipes/gmp/targets.mk
@@ -1,0 +1,2 @@
+GMP_WASM_LIB = $(WASM)/lib/libgmp.a
+OPTIONAL_WASM_LIBS += $(GMP_WASM_LIB)

--- a/libs/recipes/mpfr/rules.mk
+++ b/libs/recipes/mpfr/rules.mk
@@ -1,0 +1,22 @@
+MPFR_VERSION = 4.2.1
+MPFR_TARBALL = $(DOWNLOAD)/mpfr-$(MPFR_VERSION).tar.gz
+MPFR_URL = https://ftp.gnu.org/gnu/mpfr/mpfr-$(MPFR_VERSION).tar.xz
+
+.PHONY: mpfr
+mpfr: $(MPFR_WASM_LIB)
+
+$(MPFR_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget $(MPFR_URL) -O $@
+
+$(MPFR_WASM_LIB): $(MPFR_TARBALL) $(GMP_WASM_LIB)
+	mkdir -p $(BUILD)/mpfr-$(MPFR_VERSION)/build
+	tar -C $(BUILD) -xf $(MPFR_TARBALL)
+	cd $(BUILD)/mpfr-$(MPFR_VERSION)/build && \
+	  emconfigure ../configure \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --disable-thread-safe \
+	    --prefix=$(WASM) && \
+	  emmake make install
+

--- a/libs/recipes/mpfr/targets.mk
+++ b/libs/recipes/mpfr/targets.mk
@@ -1,0 +1,2 @@
+MPFR_WASM_LIB = $(WASM)/lib/libmpfr.a
+OPTIONAL_WASM_LIBS += $(MPFR_WASM_LIB)


### PR DESCRIPTION
Some GNU high precision libs used by many R packages, such as [igraph](https://cran.r-project.org/web/packages/igraph/index.html), [gmp](https://cran.r-project.org/web/packages/gmp/index.html), [Rmpfr](https://cran.r-project.org/web/packages/Rmpfr/index.html).

For a full list of packages linking to these packages see: https://r-universe.dev/sysdeps/

