### PR TITLE
add library: gsl

### DIFF
--- a/libs/recipes/gsl/rules.mk
+++ b/libs/recipes/gsl/rules.mk
@@ -1,0 +1,22 @@
+GSL_VERSION = 2.7.1
+GSL_TARBALL = $(DOWNLOAD)/gsl-$(GSL_VERSION).tar.gz
+GSL_URL = https://ftp.gnu.org/gnu/gsl/gsl-$(GSL_VERSION).tar.gz
+
+.PHONY: gsl
+gsl: $(GSL_WASM_LIB)
+
+$(GSL_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget $(GSL_URL) -O $@
+
+$(GSL_WASM_LIB): $(GSL_TARBALL)
+	mkdir -p $(BUILD)/gsl-$(GSL_VERSION)/build
+	tar -C $(BUILD) -xf $(GSL_TARBALL)
+	cd $(BUILD)/gsl-$(GSL_VERSION)/build && \
+	  emconfigure ../configure \
+	    --enable-shared=no \
+	    --enable-static=yes \
+	    --prefix=$(WASM) && \
+	  emmake make &&\
+	  emmake make install
+

--- a/libs/recipes/gsl/targets.mk
+++ b/libs/recipes/gsl/targets.mk
@@ -1,0 +1,2 @@
+GSL_WASM_LIB = $(WASM)/lib/libgsl.a
+OPTIONAL_WASM_LIBS += $(GSL_WASM_LIB)


### PR DESCRIPTION
Seems to work with CRAN package gsl:

```
...
emcc -s SIDE_MODULE=1 -s WASM_BIGINT -s ASSERTIONS=1 -L/opt/webr/wasm/lib -L/opt/webr/wasm/R-4.3.0/lib/R/lib -s USE_BZIP2=1 -s USE_ZLIB=1 -fwasm-exceptions -s SUPPORT_LONGJMP=wasm -Oz -o gsl.so airy.o bessel.o clausen.o coulomb.o coupling.o dawson.o debye.o dilog.o ellint.o elljac.o error.o expint.o fermi_dirac.o gamma.o gegenbauer.o hyperg.o init.o laguerre.o lambert.o legendre.o log.o poly.o pow_int.o psi.o qrng.o rng.o synchrotron.o transport.o trig.o vector.o zeta.o -L/opt/webr/wasm/lib -lgsl -lgslcblas -lm
installing to /tmp/RtmpC56q0r/file213f33e8666e/gsl/libs
** R
** inst
** preparing package for lazy loading
** help
*** installing help indices
*** copying figures
** building package indices
** installing vignettes
* creating tarball
packaged installation of 'gsl' as 'gsl_2.1-8_R_x86_64-pc-linux-gnu.tar.gz'
* DONE (gsl)
Packaging: gsl_2.1-8.data
```