### PR TITLE
CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+title: "webR: The statistical language R compiled to WebAssembly via
+  Emscripten"
+message: "If you wish to cite this software, please do so as below."  
+type: software
+authors:
+  - given-names: George William
+    family-names: Stagg
+    email: george@stagg.phd
+    affiliation: 'Posit, PBC'
+  - given-names: Henry
+    family-names: Lionel
+    affiliation: 'Posit, PBC'
+    orcid: 'https://orcid.org/0000-0002-8143-5908'
+  - given-names: Others
+repository-code: 'https://github.com/r-wasm/webr'
+url: 'https://docs.r-wasm.org/webr/latest/'
+license: MIT
+commit: 71acd7ce6e7053780fd5bb006d955ce042d27f0d
+version: 0.2.2
+date-released: '2023-11-16'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,10 +6,11 @@ type: software
 authors:
   - given-names: George William
     family-names: Stagg
-    email: george@stagg.phd
+    email: george.stagg@posit.co
     affiliation: 'Posit, PBC'
   - given-names: Henry
     family-names: Lionel
+    email: lionel@posit.co
     affiliation: 'Posit, PBC'
     orcid: 'https://orcid.org/0000-0002-8143-5908'
   - given-names: Others


### PR DESCRIPTION
Following from #353, I created a `CITATION.cff` using the [CFFINT](https://citation-file-format.github.io/cff-initializer-javascript/#/) tool. The `cff` citation file format is [recognized by GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) and will add into the right-hand side a "Cite this repository" option.

<img width="182" alt="Screenshot showing the cite this repository option added" src="https://github.com/r-wasm/webr/assets/833642/21a62736-a26a-4414-b719-57c6dfc78ac0">

If you would like, I could also add the relevant citation information to the `docs` website and/or at the end of the README.
