### PR TITLE
Install Rust toolchnain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,23 @@ ENV WEBR_ROOT="/opt/webr"
 ENV EM_NODE_JS="/usr/bin/node"
 ENV EMFC="/opt/flang/host/bin/flang-new"
 
+# Step 1: Build fake Rust DEB packages
+# 
+# Installing this makes sure the toolchain installed in the later step is used
+# instead of the one that the distro (Ubuntu) provides.
+FROM webr as deb_build
+RUN mkdir /opt/fake_rust/ && \
+    apt-get update && \
+	apt-get install -y equivs lsb-release &&\
+	equivs-control fake_rust && \
+	sed -i 's/Package:.*/Package: rustc/' fake_rust && \
+	sed -i 's/# Version:.*/Version: 99.0/' fake_rust && \
+	equivs-build fake_rust && \
+	sed -i 's/Package:.*/Package: cargo/' fake_rust && \
+	equivs-build fake_rust && \
+    mv rustc_99.0_all.deb cargo_99.0_all.deb /opt/fake_rust/
+
+# Step 2: Do the necessary setups
 FROM webr as scratch
 # Install node 18
 RUN mkdir -p /etc/apt/keyrings && \
@@ -19,6 +36,34 @@ RUN mkdir -p /etc/apt/keyrings && \
     apt-get update && \
     apt-get install nodejs -y
 
+# Install Rust; these lines are based on the official Rust docker image:
+# https://github.com/rust-lang/docker-rust/blob/master/Dockerfile-debian.template
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+RUN set -eux; \
+    wget "https://static.rust-lang.org/rustup/archive/1.26.0/x86_64-unknown-linux-gnu/rustup-init"; \
+    echo "0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y \
+        --no-modify-path \
+        --profile minimal \
+        --default-toolchain nightly \
+        --default-host x86_64-unknown-linux-gnu \
+        --target wasm32-unknown-emscripten \
+        --component rust-src; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# Install the fake Rust DEB packages. 
+COPY --from=deb_build /opt/fake_rust /tmp/fake_rust
+RUN dpkg -i /tmp/fake_rust/rustc_99.0_all.deb && \
+    dpkg -i /tmp/fake_rust/cargo_99.0_all.deb && \
+    rm -rf /tmp/fake_rust
+
+# Install rig
 RUN curl -L https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg && \
     echo "deb http://rig.r-pkg.org/deb rig main" > /etc/apt/sources.list.d/rig.list && \
     apt-get update && \
@@ -46,8 +91,11 @@ RUN rm -rf /tmp/rig
 RUN rm -rf libs/download libs/build src/node_modules R/download
 RUN cd src && make clean
 
-# Squash docker image layers
+# Step 3: Squash docker image layers
 FROM webr
 COPY --from=scratch / /
+ENV PATH="/usr/local/cargo/bin:${PATH}"
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
 WORKDIR /root
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN mkdir -p /etc/apt/keyrings && \
 
 # Install Rust; these lines are based on the official Rust docker image:
 # https://github.com/rust-lang/docker-rust/blob/master/Dockerfile-debian.template
+ENV PATH="/usr/local/cargo/bin:${PATH}"
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 RUN set -eux; \

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Additional optional Wasm system libraries for linking with R packages: libsodium (#333), webp (#334), imagemagick (#336), libarchive; lz4; zstd (#337), gmp; mpfr; glpk (#339), gsl (#340), libgit2 (#342).
 
+* The webR development Docker container now contains a Rust toolchain configured to produce binaries for the `wasm32-unknown-emscripten` target, enabling the building of R packages containing Rust code for webR.
+
 ## Breaking changes
 
 * Upgraded the base LLVM distribution from LLVM 14 to LLVM 17, rebasing our Fortran for WebAssembly patches on the latest release of LLVM at time of writing (v17.0.6). The LLVM Fortran compiler binary name is now `flang-new` and webR's build scripts have been updated to reflect this. The `emfc` wrapper script is no longer required, but for the moment the Make variable pointing to the `flang-new` compiler is still named `EMFC` for backwards compatibility.


### PR DESCRIPTION
Fix https://github.com/r-wasm/rwasm/issues/20

This pull request adds two things:

1. Install the nightly Rust toolchain and `wasm32-unknown-emscripten` target
2. Install fake DEB packages of `rustc` and `cargo` in order to prevent another Rust toolchain from being installed via `apt`.

The second point is optional, so if you prefer not adding this, I'll remove.

You can inspect the docker image built from this Docker file by:

```sh
docker pull ghcr.io/yutannihilation/webr-rust:main
```

~~(I'm rebuilding the image at the time of creating this pull request as I tweaked some orders. I think the change won't matter, but just for making sure...)~~ done!

<details>

```
$ docker manifest inspect ghcr.io/yutannihilation/webr-rust:main | grep size
                "size": 4393,
                        "size": 30439111,
                        "size": 629569132,
                        "size": 718266714,
                        "size": 32,
```
= 1.38GB

</details>