### PR TITLE
Update plotting.qmd  - bad import in code example "Capturing Plots"

### DIFF
--- a/src/docs/plotting.qmd
+++ b/src/docs/plotting.qmd
@@ -272,7 +272,7 @@ In the following example, a set of demo plots are captured and then displayed on
     </div>
 
     <script type="module">
-      import { Console } from 'https://webr.r-wasm.org/latest/webr.mjs';
+      import { WebR } from 'https://webr.r-wasm.org/latest/webr.mjs';
       const webR = new WebR();
       await webR.init();
 


### PR DESCRIPTION
The code for the example "Capturing Plots" throws the error  "Uncaught ReferenceError: WebR is not defined". 
 https://docs.r-wasm.org/webr/latest/plotting.html#capturing-plots
The line 
 import { Console } from 'https://webr.r-wasm.org/latest/webr.mjs';
should be:
 import { WebR } from 'https://webr.r-wasm.org/latest/webr.mjs';