### PR TITLE
Pass arguments to `webr::canvas()` graphics device during `captureR()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # webR (development version)
 
+## New features
+
+* The `captureGraphics` option in `EvalROptions` now allows the caller to set the arguments to be passed to the capturing `webr::canvas()` device.
+
+## Breaking changes
+
+## Bug Fixes
+
+* When capturing graphics with `captureR()`, clean-up now occurs even when the evaluated R code throws an error. This avoids leaking graphics devices on the device stack.
+
 # webR 0.3.1
 
 Hotfix release to manage incompatible WebAssembly binary R packages due to ABI changes in Emscripten.

--- a/src/docs/plotting.qmd
+++ b/src/docs/plotting.qmd
@@ -293,6 +293,19 @@ In the following example, a set of demo plots are captured and then displayed on
 </html>
 ```
 
+Arguments for the capturing `webr::canvas()` graphics device that's used during evaluation, such as setting a custom width or height, can be included as part of the optional [`EvalROptions`](api/js/interfaces/WebRChan.EvalROptions.md) argument to `captureR()`:
+
+``` javascript
+const shelter = await new webR.Shelter();
+const capture = await shelter.captureR("hist(rnorm(1000))", {
+  captureGraphics: {
+    width: 504,
+    height: 252,
+    bg: "cornsilk",
+  }
+});
+```
+
 ## Plotting from the console
 
 The `Console` class includes callbacks that are used for handling image rendering. This example builds off the [interactive webR REPL Console](examples.qmd#creating-an-interactive-webr-repl-console). In addition to the console, there is a `<canvas>` element to which plots will be drawn. The callbacks `canvasImage` and `canvasNewPage` are used to draw plots.

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -72,8 +72,17 @@ export interface EvalROptions {
   captureConditions?: boolean;
   /**
    * Should a new canvas graphics device configured to capture plots be started?
+   * Either a boolean value, or an object with properties corresponding to
+   * `webr::canvas()` graphics device arguments.
+   * Default: `true`.
    */
-  captureGraphics?: boolean;
+  captureGraphics?: boolean | {
+    width: number;
+    height: number;
+    pointsize?: number;
+    bg?: string;
+    capture?: true;
+  };
   /**
    * Should the code automatically print output as if it were written at an R console?
    * Default: `false`.


### PR DESCRIPTION
Fixes #390.

@coatless What do you think of this implementation? Here in addition to accepting `captureGraphics: true` or `false`, optional arguments can be passed to the graphics device in the following way:

``` javascript
const shelter = await new webR.Shelter();
const capture = await shelter.captureR("hist(rnorm(1000))", {
  captureGraphics: {
    width: 504,
    height: 252,
  }
});
```

Passing an object here implies `capture: true`. This should allow for evaluation-level setting of graphics device options without having to start the device manually in the provided R code.

