### PR TITLE
Reserve JavaScript objects and object arrays for R `data.frame` objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * A subclass `RDataFrame` is now available for explicit construction of an R object with class `data.frame`. `RDataFrame` extends the `RList` class, and construction must be with data that can be coerced into an R `data.frame`, otherwise an error is thrown.
 
+* The `RList` constructor now takes an optional second argument to define names when constructing a list. The argument should be an array of strings, or `null` for an unnamed list (the default).
+
 ## Breaking changes
 
 * When using the generic `RObject` constructor, JavaScript objects and object arrays are now reserved for constructing an R `data.frame`. To create a standard R list, use the `RList` constructor directly.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,11 @@
 
 * The `captureGraphics` option in `EvalROptions` now allows the caller to set the arguments to be passed to the capturing `webr::canvas()` device.
 
+* A subclass `RDataFrame` is now available for explicit construction of an R object with class `data.frame`. `RDataFrame` extends the `RList` class, and construction must be with data that can be coerced into an R `data.frame`, otherwise an error is thrown.
+
 ## Breaking changes
+
+* When using the generic `RObject` constructor, JavaScript objects and object arrays are now reserved for constructing an R `data.frame`. To create a standard R list, use the `RList` constructor directly.
 
 ## Bug Fixes
 

--- a/src/docs/convert-js-to-r.qmd
+++ b/src/docs/convert-js-to-r.qmd
@@ -8,7 +8,7 @@ Once webR has been loaded into a web page, new R objects can be created from the
 
 ## Creating new R objects
 
-New R objects can be created from the main JavaScript thread by using the `new` operator with proxy classes on an initialised instance of the [`WebR`](api/js/classes/WebR.WebR.md) class.
+New R objects can be created from the main JavaScript thread by using the `new` operator with proxy classes on an initialised instance of the [`WebR`](api/js/classes/WebR.WebR.md) class. The `RObject` proxy class can be used as a general constructor for creating new R objects from a given JavaScript argument.
 
 When an R object is instantiated in this way, webR communicates with the worker thread to orchestrate object creation in WebAssembly memory. As such, new R objects can only be created once communication with the worker thread has been established and the promise returned by [`WebR.init()`](api/js/classes/WebR.WebR.md#init) has resolved.
 
@@ -47,38 +47,36 @@ Sometimes webR constructs new R objects implicitly behind the scenes. For instan
 
 ### Constructing R objects from JavaScript objects
 
-The [`WebR` proxy classes](api/js/classes/WebR.WebR.md#properties) take a single JavaScript argument in their constructor functions which will be used for the content of the new R object. JavaScript objects that are able to be converted for use as R objects have type [`WebRData`](api/js/modules/RObject.md#webrdata).
+When using the generic `RObject` constructor the resulting R object type is chosen based on the contents of the JavaScript argument provided. Where there is ambiguity, the following conversion rules are used,
 
-The resulting R object type is chosen based on the contents of the JavaScript argument provided. When there is ambiguity, the following conversion rules are used,
-
-| Constructor Argument                                                     | R Type                                                                      |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| `null`                                                                   | Logical `NA`                                                                |
-| `boolean`                                                                | Logical atomic vector                                                       |
-| `number`                                                                 | Double atomic vector                                                        |
-| `{ re: 1, im: 2 }`                                                       | Complex atomic vector                                                       |
-| `string`                                                                 | Character atomic vector                                                     |
-| `TypedArray`, `ArrayBuffer`, `ArrayBufferView`                           | Raw atomic vector                                                           |
-| `Array`                                                                  | A vector or list of type following the coercion rules of R's `c()` function |
-| `RObject`                                                                | Given by the type of the referenced R object                                |
-| `{a: [...], b: [...], ...}`                                              | R list object, possibly in the form of a `data.frame`                       |
-| `[{a: 0, b: 'x'}, {a: 1, b: 'y'}, ...]`                                  | R list object in the form of a `data.frame`                                 |
-| [`WebRDataJs`](convert-r-to-js.qmd#serialising-r-objects)                | Given by the `type` property in the provided object                         |
-| Other JavaScript object                                                  | Reserved for future use                                                     |
+| Constructor Argument                                      | R Type                                                      |
+|-----------------------------------------------------------|-------------------------------------------------------------|
+| `null`                                                    | Logical `NA`                                                |
+| `boolean`                                                 | Logical atomic vector                                       |
+| `number`                                                  | Double atomic vector                                        |
+| `{ re: 1, im: 2 }`                                        | Complex atomic vector                                       |
+| `string`                                                  | Character atomic vector                                     |
+| `TypedArray`, `ArrayBuffer`, `ArrayBufferView`            | Raw atomic vector                                           |
+| `Array`                                                   | A vector following the coercion rules of R's `c()` function |
+| `{a: [0, 1], b: ['x', 'y']}`                              | Data frame                                                  |
+| `[{a: 0, b: 'x'}, {a: 1, b: 'y'}]`                        | Data frame                                                  |
+| `RObject`                                                 | Given by the type of the referenced R object                |
+| [`WebRDataJs`](convert-r-to-js.qmd#serialising-r-objects) | Given by the `type` property in the provided object         |
+| Other JavaScript type                                     | Reserved for future use                                     |
 
 #### Further details
 
-For JavaScript objects with a collection of properties, the above rules will be applied recursively to construct an R list with named components corresponding to each property.
+JavaScript objects (in "long" form) and JavaScript object arrays (in "wide" or "D3" form), as shown in the table above, are reserved for constructing R data frames. The object properties should correspond to data with columns of equal length and consistent data type, and values should be compatible with R atomic vectors (or `null`, indicating a missing value).
 
-If each property of the JavaScript object is an `Array`, all of equal length, all containing values compatible with R atomic vectors (or `null`, indicating a missing value), the resulting R object will be automatically^[This coercion may be avoided by constructing an `RList` object directly.] coerced into an R [`data.frame`](https://stat.ethz.ch/R-manual/R-devel/library/base/html/data.frame.html).
+The creation of a `data.frame` can be avoided by explicitly constructing an `RList` object, as shown in the next section.
 
 When `RObject` references are used for constructing new R objects, no underlying copy is made. The resulting R object reference will point to the same memory location.
 
 ### Creating an R object with specific type
 
-As an alternative to constructing an [`WebRDataJs`](api/js/modules/RObject.md#webrdatajs) with an explicit `type` property, several class proxies of different type are available on the [`WebR`](api/js/classes/WebR.WebR.md) instance. For example, the [`WebR.RList`](api/js/classes/WebR.WebR.md#rlist) class proxy can be used to specifically construct an R list object, rather than an atomic vector, using a JavaScript array of values.
+Class constructors for various types of R object are also available on the [`WebR`](api/js/classes/WebR.WebR.md) instance. For example, the [`WebR.RList`](api/js/classes/WebR.WebR.md#rlist) constructor can be used to specifically create an R list object from a given JavaScript argument, rather than the atomic vector or `data.frame` that would be created when using the generic `RObject` constructor.
 
-To see how this can be useful, consider the difference in structure between the following two R object construction examples, using the same JavaScript object as the constructor argument,
+To see how this can be useful, consider the difference in structure between the following two examples, using the same JavaScript object as the constructor argument,
 
 ``` javascript
 let foo = await new webR.RObject([123, 'abc']);
@@ -100,6 +98,8 @@ await foo.toJs();
         { type: 'character', names: null, values: ['abc'] }
       ]
     }
+
+It is recommended that specific R object constructors are used, rather than relying on the conversion rules of the generic `RObject` constructor, when webR is used non-interactively or in production.
 
 ### Creating objects using `RObject` references
 

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -620,6 +620,44 @@ describe('Create R lists from JS objects', () => {
     expect(await c.toArray()).toEqual(jsObj.c);
   });
 
+  test('Create an unnamed R list from JS array', async () => {
+    const jsArray = [[1, 2, 3], ['x', 'y', 'z']];
+    const rObj = await new webR.RList(jsArray);
+    expect(await rObj.type()).toEqual('list');
+    expect(await rObj.names()).toEqual(null);
+    const foo = await rObj.get(1) as RDouble;
+    const bar = await rObj.get(2) as RCharacter;
+    expect(await foo.toArray()).toEqual(jsArray[0]);
+    expect(await bar.toArray()).toEqual(jsArray[1]);
+  });
+
+  test('Create a named R list from values and names arrays', async () => {
+    const jsArray = [[1, 2, 3], ['x', 'y', 'z']];
+    const names = ["a", "b"];
+    const rObj = await new webR.RList(jsArray, names);
+    expect(await rObj.type()).toEqual('list');
+    expect(await rObj.names()).toEqual(names);
+    const foo = await rObj.get(1) as RDouble;
+    const bar = await rObj.get(2) as RCharacter;
+    expect(await foo.toArray()).toEqual(jsArray[0]);
+    expect(await bar.toArray()).toEqual(jsArray[1]);
+  });
+
+  test('Create a named R list with duplicate names', async () => {
+    const jsArray = [[1, 2, 3], ['x', 'y', 'z'], 7];
+    const names = ["foo", "foo", "bar"];
+    const rObj = await new webR.RList(jsArray, names);
+    expect(await rObj.type()).toEqual('list');
+    expect(await rObj.names()).toEqual(names);
+  });
+
+  test('Reject a named R list with inconsistent names length', async () => {
+    const jsArray = [[1, 2, 3], ['x', 'y', 'z']];
+    const names = ["a"];
+    const rObj = new webR.RList(jsArray, names);
+    await expect(rObj).rejects.toThrow("Can't construct named `RList`");
+  });
+
   test('Create an R list from JS object with coercion and missing values', async () => {
     const jsObj = { a: [0, true], b: [null, 4, '5'], c: [null] };
     const rObj = await new webR.RList(jsObj);

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -186,13 +186,13 @@ async function newRObject(
   chan: ChannelMain,
   objType: RType | RCtor,
   shelter: ShelterID,
-  value: WebRData
+  ...args: WebRData[]
 ) {
   const msg: NewRObjectMessage = {
     type: 'newRObject',
     data: {
       objType,
-      obj: replaceInObject(value, isRObject, (obj: RObject) => obj._payload),
+      args: replaceInObject<WebRData[]>(args, isRObject, (obj: RObject) => obj._payload),
       shelter: shelter,
     },
   };
@@ -256,7 +256,7 @@ export function newRClassProxy<T, R>(
   objType: RType | RCtor
 ) {
   return new Proxy(RWorker.RObject, {
-    construct: (_, args: [WebRData]) => newRObject(chan, objType, shelter, ...args),
+    construct: (_, args: WebRData[]) => newRObject(chan, objType, shelter, ...args),
     get: (_, prop: string | number | symbol) => {
       return targetMethod(chan, prop.toString());
     },

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -6,7 +6,7 @@
 import { ChannelMain } from './chan/channel';
 import { replaceInObject } from './utils';
 import { isWebRPayloadPtr, WebRPayloadPtr, WebRPayload } from './payload';
-import { RType, RClass, WebRData, WebRDataRaw } from './robj';
+import { RType, RCtor, WebRData, WebRDataRaw } from './robj';
 import { isRObject, RObject, isRFunction } from './robj-main';
 import * as RWorker from './robj-worker';
 import { ShelterID, CallRObjectMethodMessage, NewRObjectMessage } from './webr-chan';
@@ -184,7 +184,7 @@ export function targetMethod(chan: ChannelMain, prop: string, payload?: WebRPayl
  */
 async function newRObject(
   chan: ChannelMain,
-  objType: RType | RClass,
+  objType: RType | RCtor,
   shelter: ShelterID,
   value: WebRData
 ) {
@@ -253,7 +253,7 @@ export function newRProxy(chan: ChannelMain, payload: WebRPayloadPtr): RProxy<RW
 export function newRClassProxy<T, R>(
   chan: ChannelMain,
   shelter: ShelterID,
-  objType: RType | RClass
+  objType: RType | RCtor
 ) {
   return new Proxy(RWorker.RObject, {
     construct: (_, args: [WebRData]) => newRObject(chan, objType, shelter, ...args),

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -243,7 +243,7 @@ export function newRProxy(chan: ChannelMain, payload: WebRPayloadPtr): RProxy<RW
  * Proxy an {@link RWorker.RObject} class.s
  * @param {ChannelMain} chan The current main thread communication channel.
  * @param {ShelterID} shelter The shelter ID to protect returned objects with.
- * @param {(RType | RClass)} objType The R object type or class, `'object'` for
+ * @param {(RType | RCtor)} objType The R object type or class, `'object'` for
  * the generic {@link RWorker.RObject} class.
  * @returns {ProxyConstructor} A proxy to the R object subclass corresponding to
  * the given value of the `objType` argument.

--- a/src/webR/proxy.ts
+++ b/src/webR/proxy.ts
@@ -6,7 +6,7 @@
 import { ChannelMain } from './chan/channel';
 import { replaceInObject } from './utils';
 import { isWebRPayloadPtr, WebRPayloadPtr, WebRPayload } from './payload';
-import { RType, WebRData, WebRDataRaw } from './robj';
+import { RType, RClass, WebRData, WebRDataRaw } from './robj';
 import { isRObject, RObject, isRFunction } from './robj-main';
 import * as RWorker from './robj-worker';
 import { ShelterID, CallRObjectMethodMessage, NewRObjectMessage } from './webr-chan';
@@ -184,7 +184,7 @@ export function targetMethod(chan: ChannelMain, prop: string, payload?: WebRPayl
  */
 async function newRObject(
   chan: ChannelMain,
-  objType: RType | 'object',
+  objType: RType | RClass,
   shelter: ShelterID,
   value: WebRData
 ) {
@@ -243,8 +243,8 @@ export function newRProxy(chan: ChannelMain, payload: WebRPayloadPtr): RProxy<RW
  * Proxy an {@link RWorker.RObject} class.s
  * @param {ChannelMain} chan The current main thread communication channel.
  * @param {ShelterID} shelter The shelter ID to protect returned objects with.
- * @param {(RType | 'object')} objType The R object type, or `'object'` for the
- * generic {@link RWorker.RObject} class.
+ * @param {(RType | RClass)} objType The R object type or class, `'object'` for
+ * the generic {@link RWorker.RObject} class.
  * @returns {ProxyConstructor} A proxy to the R object subclass corresponding to
  * the given value of the `objType` argument.
  * @typeParam T The type of the {@link RWorker.RObject} class to be proxied.
@@ -253,7 +253,7 @@ export function newRProxy(chan: ChannelMain, payload: WebRPayloadPtr): RProxy<RW
 export function newRClassProxy<T, R>(
   chan: ChannelMain,
   shelter: ShelterID,
-  objType: RType | 'object'
+  objType: RType | RClass
 ) {
   return new Proxy(RWorker.RObject, {
     construct: (_, args: [WebRData]) => newRObject(chan, objType, shelter, ...args),

--- a/src/webR/robj-main.ts
+++ b/src/webR/robj-main.ts
@@ -24,6 +24,7 @@ export type RDouble = RProxy<RWorker.RDouble>;
 export type RComplex = RProxy<RWorker.RComplex>;
 export type RCharacter = RProxy<RWorker.RCharacter>;
 export type RList = RProxy<RWorker.RList>;
+export type RDataFrame = RProxy<RWorker.RDataFrame>;
 export type RRaw = RProxy<RWorker.RRaw>;
 export type RCall = RProxy<RWorker.RCall>;
 // RFunction proxies are callable

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -38,7 +38,9 @@ export const RTypeMap = {
 } as const;
 export type RType = keyof typeof RTypeMap;
 export type RTypeNumber = typeof RTypeMap[RType];
-export type RClass = 'object';
+
+/** @internal */
+export type RCtor = 'object' | 'dataframe';
 
 export type Complex = {
   re: number;

--- a/src/webR/robj.ts
+++ b/src/webR/robj.ts
@@ -37,7 +37,8 @@ export const RTypeMap = {
   function: 99,
 } as const;
 export type RType = keyof typeof RTypeMap;
-export type RTypeNumber = (typeof RTypeMap)[keyof typeof RTypeMap];
+export type RTypeNumber = typeof RTypeMap[RType];
+export type RClass = 'object';
 
 export type Complex = {
   re: number;

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -5,7 +5,7 @@ import { Message } from './chan/message';
 import { UUID as ShelterID } from './chan/task-common';
 import { EmPtr } from './emscripten';
 import { WebRPayloadWorker, WebRPayloadPtr } from './payload';
-import { RType, RClass, WebRData } from './robj';
+import { RType, RCtor, WebRData } from './robj';
 import type { FSType, FSMountOptions } from './webr-main';
 
 export { isUUID as isShelterID, UUID as ShelterID } from './chan/task-common';
@@ -186,7 +186,7 @@ export interface NewRObjectMessage extends Message {
   type: 'newRObject';
   data: {
     obj: WebRData;
-    objType: RType | RClass;
+    objType: RType | RCtor;
     shelter: ShelterID;
   };
 }

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -185,7 +185,7 @@ export interface InvokeWasmFunctionMessage extends Message {
 export interface NewRObjectMessage extends Message {
   type: 'newRObject';
   data: {
-    obj: WebRData;
+    args: WebRData[];
     objType: RType | RCtor;
     shelter: ShelterID;
   };

--- a/src/webR/webr-chan.ts
+++ b/src/webR/webr-chan.ts
@@ -5,7 +5,7 @@ import { Message } from './chan/message';
 import { UUID as ShelterID } from './chan/task-common';
 import { EmPtr } from './emscripten';
 import { WebRPayloadWorker, WebRPayloadPtr } from './payload';
-import { RType, WebRData } from './robj';
+import { RType, RClass, WebRData } from './robj';
 import type { FSType, FSMountOptions } from './webr-main';
 
 export { isUUID as isShelterID, UUID as ShelterID } from './chan/task-common';
@@ -186,7 +186,7 @@ export interface NewRObjectMessage extends Message {
   type: 'newRObject';
   data: {
     obj: WebRData;
-    objType: RType | 'object';
+    objType: RType | RClass;
     shelter: ShelterID;
   };
 }

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -11,8 +11,8 @@ import { EmPtr } from './emscripten';
 import { WebRPayloadPtr } from './payload';
 import { newRProxy, newRClassProxy } from './proxy';
 import { isRObject, RCharacter, RComplex, RDouble } from './robj-main';
-import { REnvironment, RSymbol, RInteger } from './robj-main';
-import { RList, RLogical, RNull, RObject, RPairlist, RRaw, RString, RCall } from './robj-main';
+import { REnvironment, RSymbol, RInteger, RList, RDataFrame } from './robj-main';
+import { RLogical, RNull, RObject, RPairlist, RRaw, RString, RCall } from './robj-main';
 import { replaceInObject } from './utils';
 import * as RWorker from './robj-worker';
 import { WebRError, WebRPayloadError } from './error';
@@ -208,6 +208,7 @@ export class WebR {
   RComplex!: ReturnType<typeof newRClassProxy<typeof RWorker.RComplex, RComplex>>;
   RRaw!: ReturnType<typeof newRClassProxy<typeof RWorker.RRaw, RRaw>>;
   RList!: ReturnType<typeof newRClassProxy<typeof RWorker.RList, RList>>;
+  RDataFrame!: ReturnType<typeof newRClassProxy<typeof RWorker.RDataFrame, RDataFrame>>;
   RPairlist!: ReturnType<typeof newRClassProxy<typeof RWorker.RPairlist, RPairlist>>;
   REnvironment!: ReturnType<typeof newRClassProxy<typeof RWorker.REnvironment, REnvironment>>;
   RSymbol!: ReturnType<typeof newRClassProxy<typeof RWorker.RSymbol, RSymbol>>;
@@ -250,6 +251,7 @@ export class WebR {
       this.RCharacter = this.globalShelter.RCharacter;
       this.RRaw = this.globalShelter.RRaw;
       this.RList = this.globalShelter.RList;
+      this.RDataFrame = this.globalShelter.RDataFrame;
       this.RPairlist = this.globalShelter.RPairlist;
       this.REnvironment = this.globalShelter.REnvironment;
       this.RSymbol = this.globalShelter.RSymbol;
@@ -508,6 +510,7 @@ export class Shelter {
   RComplex!: ReturnType<typeof newRClassProxy<typeof RWorker.RComplex, RComplex>>;
   RRaw!: ReturnType<typeof newRClassProxy<typeof RWorker.RRaw, RRaw>>;
   RList!: ReturnType<typeof newRClassProxy<typeof RWorker.RList, RList>>;
+  RDataFrame!: ReturnType<typeof newRClassProxy<typeof RWorker.RDataFrame, RDataFrame>>;
   RPairlist!: ReturnType<typeof newRClassProxy<typeof RWorker.RPairlist, RPairlist>>;
   REnvironment!: ReturnType<typeof newRClassProxy<typeof RWorker.REnvironment, REnvironment>>;
   RSymbol!: ReturnType<typeof newRClassProxy<typeof RWorker.RSymbol, RSymbol>>;
@@ -537,6 +540,7 @@ export class Shelter {
     this.RCharacter = newRClassProxy<typeof RWorker.RCharacter, RCharacter>(this.#chan, this.#id, 'character');
     this.RRaw = newRClassProxy<typeof RWorker.RRaw, RRaw>(this.#chan, this.#id, 'raw');
     this.RList = newRClassProxy<typeof RWorker.RList, RList>(this.#chan, this.#id, 'list');
+    this.RDataFrame = newRClassProxy<typeof RWorker.RDataFrame, RDataFrame>(this.#chan, this.#id, 'dataframe');
     this.RPairlist = newRClassProxy<typeof RWorker.RPairlist, RPairlist>(this.#chan, this.#id, 'pairlist');
     this.REnvironment = newRClassProxy<typeof RWorker.REnvironment, REnvironment>(this.#chan, this.#id, 'environment');
     this.RSymbol = newRClassProxy<typeof RWorker.RSymbol, RSymbol>(this.#chan, this.#id, 'symbol');

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -10,7 +10,7 @@ import { WebRPayloadRaw, WebRPayloadPtr, WebRPayloadWorker, isWebRPayloadPtr } f
 import { RObject, isRObject, REnvironment, RList, RCall, getRWorkerClass } from './robj-worker';
 import { RCharacter, RString, keep, destroy, purge, shelters } from './robj-worker';
 import { RLogical, RInteger, RDouble, initPersistentObjects, objs } from './robj-worker';
-import { RPtr, RType, RClass, WebRData, WebRDataRaw } from './robj';
+import { RPtr, RType, RCtor, WebRData, WebRDataRaw } from './robj';
 import { protect, protectInc, unprotect, parseEvalBare, UnwindProtectException, safeEval } from './utils-r';
 import { generateUUID } from './chan/task-common';
 
@@ -588,7 +588,7 @@ function mountImagePath(path: string, mountpoint: string) {
   mountImageData(buf, metadata, mountpoint);
 }
 
-function newRObject(data: WebRData, objType: RType | RClass): WebRPayloadPtr {
+function newRObject(data: WebRData, objType: RType | RCtor): WebRPayloadPtr {
   const RClass = getRWorkerClass(objType);
   const obj = new RClass(
     replaceInObject(data, isWebRPayloadPtr, (t: WebRPayloadPtr) =>
@@ -682,9 +682,9 @@ function captureR(expr: string | RObject, options: EvalROptions = {}): {
       }
 
       // User supplied canvas arguments, if any. Default: `capture = TRUE`
-      devEnvObj.bind('canvas_options', Object.assign({
+      devEnvObj.bind('canvas_options', new RList(Object.assign({
         capture: true
-      }, _options.captureGraphics));
+      }, _options.captureGraphics)));
 
       parseEvalBare(`{
         old_dev <- dev.cur()

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -389,7 +389,7 @@ function dispatch(msg: Message): void {
           case 'newRObject': {
             const msg = reqMsg as NewRObjectMessage;
 
-            const payload = newRObject(msg.data.obj, msg.data.objType);
+            const payload = newRObject(msg.data.args, msg.data.objType);
             keep(msg.data.shelter, payload.obj.ptr);
 
             write(payload);
@@ -588,13 +588,12 @@ function mountImagePath(path: string, mountpoint: string) {
   mountImageData(buf, metadata, mountpoint);
 }
 
-function newRObject(data: WebRData, objType: RType | RCtor): WebRPayloadPtr {
+function newRObject(args: WebRData[], objType: RType | RCtor): WebRPayloadPtr {
   const RClass = getRWorkerClass(objType);
-  const obj = new RClass(
-    replaceInObject(data, isWebRPayloadPtr, (t: WebRPayloadPtr) =>
-      RObject.wrap(t.obj.ptr)
-    ) as WebRData
+  const _args = replaceInObject<WebRData[]>(args, isWebRPayloadPtr, (t: WebRPayloadPtr) =>
+    RObject.wrap(t.obj.ptr)
   );
+  const obj = new RClass(..._args);
   return {
     obj: {
       type: obj.type(),

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -10,7 +10,7 @@ import { WebRPayloadRaw, WebRPayloadPtr, WebRPayloadWorker, isWebRPayloadPtr } f
 import { RObject, isRObject, REnvironment, RList, RCall, getRWorkerClass } from './robj-worker';
 import { RCharacter, RString, keep, destroy, purge, shelters } from './robj-worker';
 import { RLogical, RInteger, RDouble, initPersistentObjects, objs } from './robj-worker';
-import { RPtr, RType, RTypeMap, WebRData, WebRDataRaw } from './robj';
+import { RPtr, RType, RClass, WebRData, WebRDataRaw } from './robj';
 import { protect, protectInc, unprotect, parseEvalBare, UnwindProtectException, safeEval } from './utils-r';
 import { generateUUID } from './chan/task-common';
 
@@ -588,8 +588,8 @@ function mountImagePath(path: string, mountpoint: string) {
   mountImageData(buf, metadata, mountpoint);
 }
 
-function newRObject(data: WebRData, objType: RType | 'object'): WebRPayloadPtr {
-  const RClass = objType === 'object' ? RObject : getRWorkerClass(RTypeMap[objType]);
+function newRObject(data: WebRData, objType: RType | RClass): WebRPayloadPtr {
+  const RClass = getRWorkerClass(objType);
   const obj = new RClass(
     replaceInObject(data, isWebRPayloadPtr, (t: WebRPayloadPtr) =>
       RObject.wrap(t.obj.ptr)


### PR DESCRIPTION
Fixes #398.

Reserve JavaScript objects and object arrays for R `data.frame` objects when constructing R objects with the generic `RObject` constructor. Also adds the `RDataFrame` helper class constructor for constructing an R `data.frame` explicitly.

@lionel- How does this look? With these changes, using the generic constructor looks like:

```js
// Creates `data.frame`
await new webR.RObject({ a: [1, 2, 3], b: ['x', 'y', 'z'] }); 

// Throws an error, inconsistent column length
await new webR.RObject({ a: [1, 2, 3], b: ['x', 'y'] });
//Uncaught Error: Can't construct `data.frame`. Source object is not eligible.

// Creates a list, syntax supports duplicate names
await new webR.RObject({
  type: 'list',
  names: ['a', 'b'],
  values: [[1, 2, 3], ['x', 'y']]
});

// Also creates other types of R objects as before, using heuristics
await new webR.RObject([1, 2, 3]); 
```

And we have specific `RList` and `RDataFrame` constructors:

```js
// Creates a list, no `data.frame` class
await new webR.RList({ a: [1, 2, 3], b: ['x', 'y', 'z'] });

// Creates a list without error, but this JS form does not support duplicate names
await new webR.RList({ a: [1, 2, 3], b: ['x', 'y'] });

// Creates `data.frame`, as with `RObject
await new webR.RDataFrame({ a: [1, 2, 3], b: ['x', 'y', 'z'] });
await new webR.RDataFrame([{a: 1, b: 'x'}, {a: 2, b: 'y'}, {a: 3, b: 'z'} ]);

// Throws an error, inconsistent columns
await new webR.RDataFrame([{a: 1, b: 'x'}, {a: 2, b: 'y'}, {a: 3, b: 'z', c: true} ]);
// Uncaught Error: Can't construct `data.frame`. Source object is not eligible.

// Unlike with the generic `RObject` constructor, this does not fall back to heuristics
await new webR.RDataFrame([1, 2, 3]); 
// Uncaught Error: Can't construct `data.frame`. Source object is not eligible.
```