### PR TITLE
change how package.json specifies types file

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -38,20 +38,17 @@
     "dist"
   ],
   "main": "dist/webr.mjs",
-  "types": "dist/webr/webr-main.d.ts",
+  "types": "dist/webR/webr-main.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/webR/webr-main.d.ts",
       "node": "./dist/webr.cjs",
-      "types": "./dist/webr/webr-main.d.ts",
       "default": "./dist/webr.mjs"
     },
-    "./chan/serviceworker": "./dist/webr-serviceworker.mjs"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "dist/webR/*"
-      ]
+    "./chan/serviceworker": {
+      "types": "./dist/webR/chan/serviceworker.d.ts",
+      "browser": "./dist/webr-serviceworker.js",
+      "default": "./dist/webr-serviceworker.mjs"
     }
   },
   "engines": {

--- a/src/package.json
+++ b/src/package.json
@@ -38,11 +38,12 @@
     "dist"
   ],
   "main": "dist/webr.mjs",
-  "types": "webr-main.d.ts",
+  "types": "dist/webr/webr-main.d.ts",
   "exports": {
     ".": {
       "node": "./dist/webr.cjs",
-      "default": "./dist/webr.mjs"
+      "default": "./dist/webr.mjs",
+      "types": "./dist/webr/webr-main.d.ts"
     },
     "./chan/serviceworker": "./dist/webr-serviceworker.mjs"
   },

--- a/src/package.json
+++ b/src/package.json
@@ -42,8 +42,8 @@
   "exports": {
     ".": {
       "node": "./dist/webr.cjs",
-      "default": "./dist/webr.mjs",
-      "types": "./dist/webr/webr-main.d.ts"
+      "types": "./dist/webr/webr-main.d.ts",
+      "default": "./dist/webr.mjs"
     },
     "./chan/serviceworker": "./dist/webr-serviceworker.mjs"
   },


### PR DESCRIPTION
In a personal project, tweaking `package.json` led my IDE to start recognizing the types provided in webR. Without this I get compile-time warnings in the IDE.

I'm inexperienced, so others should double check this.