### PR TITLE
Add help and debug targets, fuzzy assign WEBR_ROOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,20 +8,17 @@ default: webr
 # This is created at configure-time
 include $(TOOLS)/fortran.mk
 
-# Build webR and install the web app in `./dist`
 .PHONY: webr
-webr: $(EMFC) $(FORTRAN_WASM_LIB) libs
+webr: $(EMFC) $(FORTRAN_WASM_LIB) libs ## Build webR and install the web app in `./dist`
 	cd R && $(MAKE) && $(MAKE) install
 	cd src && $(MAKE)
 
-# Supporting libs for webr
 .PHONY: libs
-libs:
+libs: ## Compile supporting libs for webR
 	cd libs && $(MAKE)
 
-# Build webR in a temporary docker container
 .PHONY: docker-webr
-docker-webr:
+docker-webr: ## Build webR in a temporary docker container
 	mkdir -p dist
 	docker build -t webr-build .
 	docker run --rm --mount type=bind,source=$(PWD),target=/app webr-build
@@ -29,32 +26,47 @@ docker-webr:
 # Create a permanent docker container for building webR. Call `make`
 # from within the container to start the build.
 .PHONY: docker-container-%
-docker-container-%:
+docker-container-%: ## Build docker container without webR built using a supplied name
 	docker build -t webr-build .
 	docker run -dit --name $* --mount type=bind,source=$(PWD),target=/app webr-build bash
 
-docs: docs/build
-docs/build:
+docs: docs/build ## Build JS documentation and Quarto website
+docs/build: ## Build JS documentation and Quarto website
 	cd docs && $(MAKE) api && $(MAKE) html
 
 .PHONY: check
-check:
+check: ## Check Nodejs coverage
 	cd src && $(MAKE) check
 
 .PHONY: check-pr
-check-pr:
+check-pr: ## Check pull request by running linting, Nodejs coverage, and Node js package check.
 	cd src && $(MAKE) lint && $(MAKE) check && $(MAKE) check-packages
 
 .PHONY: clean
-clean:
+clean:  ## Remove R WASM and R compilations
 	rm -rf $(HOST) $(WASM)/R-*
 	cd R && $(MAKE) clean
 
 .PHONY: clean-wasm
-clean-wasm: clean
+clean-wasm: clean ## Remove WASM compilation and libs
 	rm -rf $(WASM)
 	cd libs && $(MAKE) clean
 
 .PHONY: distclean
-distclean: clean-wasm clean-tools
+distclean: clean-wasm clean-tools ## Remove WASM compilation, libs, tools, and dist
 	rm -rf dist
+
+.PHONY: help
+help:  ## Show help messages for make targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-18s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: debug
+debug: ## Print all variables for debugging
+	@printf "\033[32m%-18s\033[0m %s\n" "WEBR_ROOT" "$(WEBR_ROOT)"
+	@printf "\033[32m%-18s\033[0m %s\n" "WASM" "$(WASM)"
+	@printf "\033[32m%-18s\033[0m %s\n" "HOST" "$(HOST)"
+	@printf "\033[32m%-18s\033[0m %s\n" "TOOLS" "$(TOOLS)"
+	@printf "\033[32m%-18s\033[0m %s\n" "EMFC" "$(EMFC)"
+	@printf "\033[32m%-18s\033[0m %s\n" "FORTRAN_WASM_LIB" "$(FORTRAN_WASM_LIB)"
+	@printf "\033[32m%-18s\033[0m %s\n" "PWD" "$(PWD)"
+	@printf "\033[32m%-18s\033[0m %s\n" "MAKE" "$(MAKE)"

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ docker-container-%: ## Build webR development Docker container using a supplied 
 	docker build -t webr-build .
 	docker run -dit --name $* --mount type=bind,source=$(PWD),target=/app webr-build bash
 
-docs: docs/build ## Build JS documentation and Quarto website
-docs/build: ## Build JS documentation and Quarto website
+docs: docs/build ## Build documentation and Quarto website
+docs/build: ## Build documentation and Quarto website
 	cd docs && $(MAKE) api && $(MAKE) html
 
 .PHONY: check

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ libs: ## Compile supporting libs for webR
 	cd libs && $(MAKE)
 
 .PHONY: docker-webr
-docker-webr: ## Build webR in a temporary docker container
+docker-webr: ## Build webR in a temporary Docker container
 	mkdir -p dist
 	docker build -t webr-build .
 	docker run --rm --mount type=bind,source=$(PWD),target=/app webr-build

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ docker-webr: ## Build webR in a temporary docker container
 # Create a permanent docker container for building webR. Call `make`
 # from within the container to start the build.
 .PHONY: docker-container-%
-docker-container-%: ## Build docker container without webR built using a supplied name
+docker-container-%: ## Build webR development Docker container using a supplied name
 	docker build -t webr-build .
 	docker run -dit --name $* --mount type=bind,source=$(PWD),target=/app webr-build bash
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ check-pr: ## Run additional pull request tests, linter, and calculate coverage
 	cd src && $(MAKE) lint && $(MAKE) check && $(MAKE) check-packages
 
 .PHONY: clean
-clean:  ## Remove R WASM and R compilations
+clean: ## Remove Wasm R build
 	rm -rf $(HOST) $(WASM)/R-*
 	cd R && $(MAKE) clean
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean: ## Remove Wasm R build
 	cd R && $(MAKE) clean
 
 .PHONY: clean-wasm
-clean-wasm: clean ## Remove WASM compilation and libs
+clean-wasm: clean ## Remove Wasm R build and supporting libs
 	rm -rf $(WASM)
 	cd libs && $(MAKE) clean
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ check: ## Run unit tests and calculate coverage
 	cd src && $(MAKE) check
 
 .PHONY: check-pr
-check-pr: ## Check pull request by running linting, Nodejs coverage, and Node js package check.
+check-pr: ## Run additional pull request tests, linter, and calculate coverage
 	cd src && $(MAKE) lint && $(MAKE) check && $(MAKE) check-packages
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ clean-wasm: clean ## Remove Wasm R build and supporting libs
 	cd libs && $(MAKE) clean
 
 .PHONY: distclean
-distclean: clean-wasm clean-tools ## Remove WASM compilation, libs, tools, and dist
+distclean: clean-wasm clean-tools ## Remove Wasm R build, supporting libs, build tools, and webR distribution
 	rm -rf dist
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-WEBR_ROOT = $(abspath .)
+WEBR_ROOT ?= $(abspath .)
 WASM = $(WEBR_ROOT)/wasm
 HOST = $(WEBR_ROOT)/host
 TOOLS = $(WEBR_ROOT)/tools

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ docs/build: ## Build JS documentation and Quarto website
 	cd docs && $(MAKE) api && $(MAKE) html
 
 .PHONY: check
-check: ## Check Nodejs coverage
+check: ## Run unit tests and calculate coverage
 	cd src && $(MAKE) check
 
 .PHONY: check-pr


### PR DESCRIPTION
As part of digging into the build process, I thought it would be helpful to add to the top-level `Make` file:

1. a debug variables statement; and,

<img width="1034" alt="Screenshot showing the results of `make debug`" src="https://github.com/r-wasm/webr/assets/833642/0c529cf3-76fc-4b7a-8180-6a68b956212d">


2. a help documentation statement. 

<img width="1032" alt="Screenshot showing the results of `make help`" src="https://github.com/r-wasm/webr/assets/833642/7b44fb55-78b4-4607-89c2-68e60beafd04">

I've also moved to use a conditional assignment for `WEBR_ROOT` so that it is read from the environment variable set up in the `Dockerfile`. (Note: There are a few more changes required for this to be portable, but I wanted to start small.)

I'll likely add a similar patch for each subsequent `make`s if okay. 