### PR TITLE
Flush incomplete lines when capturing streams with `Shelter.captureR()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * A `webR.version` property has been added, containing the current version and build information (#409).
 
+## Bug Fixes
+
+* WebR will now flush incomplete lines when capturing output streams with `Shelter.captureR()` (#412).
+
 # webR 0.3.2
 
 ## New features

--- a/packages/webr/R/eval.R
+++ b/packages/webr/R/eval.R
@@ -117,6 +117,10 @@ eval_r <- function(expr,
     res <- efun(expr)
   }
 
+  # Ensure incomplete lines are flushed to output vector
+  if (isIncomplete(out$stdout)) cat(fill = TRUE, file = out$stdout)
+  if (isIncomplete(out$stderr)) cat(fill = TRUE, file = out$stderr)
+
   # Output vector out$vec expands exponentially, return only the valid subset
   list(result = res, output = utils::head(out$vec, out$n))
 }

--- a/packages/webr/src/outputconnection.c
+++ b/packages/webr/src/outputconnection.c
@@ -56,6 +56,7 @@ void init_output_connection(Rconnection con, SEXP out) {
   con->close = &output_close;
   con->vfprintf = &output_vfprintf;
   con->destroy = &output_destroy;
+  con->incomplete = FALSE;
   con->canread = FALSE;
   con->canwrite = TRUE;
   con->isopen = TRUE;
@@ -129,6 +130,9 @@ int output_vfprintf(Rconnection con, const char *format, va_list ap) {
   // If we're not in the middle of a line, reset to start of buffer
   if (data->line == data->cur) {
     data->cur = data->line = data->buf;
+    con->incomplete = FALSE;
+  } else {
+    con->incomplete = TRUE;
   }
   return res;
 }

--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -145,6 +145,20 @@ describe('Evaluate R code', () => {
     void shelter.purge();
   });
 
+  test('Capture incomplete lines of output while capturing R code', async () => {
+    const shelter = await new webR.Shelter();
+    const incomplete = await shelter.captureR(`
+      cat("foo")
+      cat("bar", file = stderr())
+    `, {
+      withAutoprint: true,
+      captureStreams: true,
+    });
+    expect(incomplete.output[0]).toEqual({ type: 'stdout', data: 'foo' });
+    expect(incomplete.output[1]).toEqual({ type: 'stderr', data: 'bar' });
+    void shelter.purge();
+  });
+
   test('Capture conditions while capturing R code', async () => {
     const shelter = await new webR.Shelter();
     const res = await shelter.captureR('warning("This is a warning message")', {


### PR DESCRIPTION
Closes #412.

Before:
```js
> (await webR.globalShelter.captureR('cat("foo\nbar")')).output
< [
    {type: 'stdout', data: 'foo'},
  ]
```

After:
```js
> (await webR.globalShelter.captureR('cat("foo\nbar")')).output
< [
    {type: 'stdout', data: 'foo'},
    {type: 'stdout', data: 'bar'},
  ]
```