### PR TITLE
Use default nodejs in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,8 @@ RUN mkdir /opt/fake_rust/ && \
 
 # Step 2: Do the necessary setups
 FROM webr as scratch
-# Install node 18
-# RUN mkdir -p /etc/apt/keyrings && \
-#    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
-#    gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-#    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] \
-#    https://deb.nodesource.com/node_18.x nodistro main" | \
-#    tee /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
+# Install nodejs
+RUN apt-get update && \
     apt-get install nodejs -y
 
 # Install Rust; these lines are based on the official Rust docker image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,12 @@ RUN mkdir /opt/fake_rust/ && \
 # Step 2: Do the necessary setups
 FROM webr as scratch
 # Install node 18
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
-    gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] \
-    https://deb.nodesource.com/node_18.x nodistro main" | \
-    tee /etc/apt/sources.list.d/nodesource.list && \
+# RUN mkdir -p /etc/apt/keyrings && \
+#    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+#    gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+#    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] \
+#    https://deb.nodesource.com/node_18.x nodistro main" | \
+#    tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install nodejs -y
 


### PR DESCRIPTION
One final small suggestion:

The docker image currently downloads a custom build of node 18, but Ubuntu 24.04 ships with nodejs 18 by default: https://packages.ubuntu.com/noble/nodejs

If this version suffices, I think it would be preferable over pulling in 3rd party builds in the docker image. The latter has led to conflicts when we need to build R packages that use the `V8` R package, which requires the stock ubuntu libnode. 