### PR TITLE
Install `pak` into the system library in the webR development Docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,6 +182,7 @@ jobs:
           push: true
           build-args: |
             WEBRCI_SHA=${{ steps.short.outputs.sha }}
+            MAKE_LIBS_TARGET=all
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
   build-nix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
           push: false
           build-args: |
             WEBRCI_SHA=${{ steps.short.outputs.sha }}
+            MAKE_LIBS_TARGET=default
   build-nix:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-docker:
+  build-webr:
     runs-on: ubuntu-latest
     container: ghcr.io/r-wasm/flang-wasm:main
     steps:
@@ -40,6 +40,27 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CC_TOKEN }}
+  build-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Short commit SHA
+        id: short
+        run: |
+          SHA="${{github.event.pull_request.head.sha}}${{ github.sha }}"
+          SHORT_SHA=${SHA:0:7}
+          echo "sha: $SHORT_SHA"
+          echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          build-args: |
+            WEBRCI_SHA=${{ steps.short.outputs.sha }}
   build-nix:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,10 @@ RUN curl -L https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg 
 
 # Because $HOME gets masked by GHA with the host $HOME
 ENV R_LIBS_USER=/opt/R/current/lib/R/site-library
-RUN rig add 4.4.0
+# Don't install pak. Rig installs it into the user lib, but we want it in the system lib
+RUN rig add 4.4.0 --without-pak
+# Install pak into the system lib
+RUN /opt/R/current/bin/R -q -e 'install.packages("pak", lib = .Library)'
 
 # Download webR and configure for LLVM flang
 RUN git clone https://github.com/r-wasm/webr.git /opt/webr

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,8 @@ RUN ./configure
 RUN R CMD INSTALL packages/webr
 
 # Build webR with supporting Wasm libs
-RUN cd libs && make all
+ARG MAKE_LIBS_TARGET="all"
+RUN cd libs && make ${MAKE_LIBS_TARGET}
 RUN make
 
 # Cleanup


### PR DESCRIPTION
So as to match r-lib/actions. Avoids issues caused by pak installing a newer version of pak on top of itself.

Also adds a docker build step into the testing GHA workflow.
