### PR TITLE
Handle `WebAssembly.RuntimeError` by closing communication channel

### DIFF
--- a/src/tests/webR/webr-main.test.ts
+++ b/src/tests/webR/webr-main.test.ts
@@ -1034,6 +1034,11 @@ test('Close webR communication channel', async () => {
   // Close the channel
   tempR.close();
   await expect(closedPromise).resolves.toEqual(true);
+
+  // Writing messages after closing the channel is an error
+  expect(() => tempR.writeConsole('foo <- 123')).toThrow(
+    "The webR communication channel has been closed"
+  );
 });
 
 test('Default and user provided REnv properties are merged', async () => {

--- a/src/webR/chan/channel-postmessage.ts
+++ b/src/webR/chan/channel-postmessage.ts
@@ -266,7 +266,16 @@ export class PostMessageChannelWorker {
           this.#dispatch(msg);
         }
       } catch (e) {
-        // Don't break the REPL loop on any other Wasm issues
+        // Close on unrecoverable error
+        if (e instanceof WebAssembly.RuntimeError) {
+          this.writeSystem({ type: 'console.error', data: e.message });
+          this.writeSystem({
+            type: 'console.error',
+            data: "An unrecoverable WebAssembly error has occurred, the webR worker will be closed.",
+          });
+          this.writeSystem({ type: 'close' });
+        }
+        // Don't break the REPL loop on other Wasm `Exception` errors
         if (!(e instanceof (WebAssembly as any).Exception)) {
           throw e;
         }

--- a/src/webR/chan/channel-postmessage.ts
+++ b/src/webR/chan/channel-postmessage.ts
@@ -29,7 +29,10 @@ export class PostMessageChannelMain extends ChannelMain {
     const initWorker = (worker: Worker) => {
       this.#worker = worker;
       this.#handleEventsFromWorker(worker);
-      this.close = () => worker.terminate();
+      this.close = () => {
+        worker.terminate();
+        this.putClosedMessage();
+      };
       const msg = {
         type: 'init',
         data: { config, channelType: ChannelType.PostMessage },

--- a/src/webR/chan/channel-service.ts
+++ b/src/webR/chan/channel-service.ts
@@ -297,7 +297,19 @@ export class ServiceWorkerChannelWorker implements ChannelWorker {
   }
 
   run(args: string[]) {
-    Module.callMain(args);
+    try{
+      Module.callMain(args);
+    } catch (e) {
+      if (e instanceof WebAssembly.RuntimeError) {
+        this.writeSystem({ type: 'console.error', data: e.message });
+        this.writeSystem({
+          type: 'console.error',
+          data: "An unrecoverable WebAssembly error has occurred, the webR worker will be closed.",
+        });
+        this.writeSystem({ type: 'close' });
+      }
+      throw e;
+    }
   }
 
   setInterrupt(interrupt: () => void) {

--- a/src/webR/chan/channel-shared.ts
+++ b/src/webR/chan/channel-shared.ts
@@ -175,7 +175,19 @@ export class SharedBufferChannelWorker implements ChannelWorker {
   }
 
   run(args: string[]) {
-    Module.callMain(args);
+    try{
+      Module.callMain(args);
+    } catch (e) {
+      if (e instanceof WebAssembly.RuntimeError) {
+        this.writeSystem({ type: 'console.error', data: e.message });
+        this.writeSystem({
+          type: 'console.error',
+          data: "An unrecoverable WebAssembly error has occurred, the webR worker will be closed.",
+        });
+        this.writeSystem({ type: 'close' });
+      }
+      throw e;
+    }
   }
 
   setInterrupt(interrupt: () => void) {

--- a/src/webR/chan/channel.ts
+++ b/src/webR/chan/channel.ts
@@ -7,6 +7,7 @@ import { promiseHandles, ResolveFn, RejectFn } from '../utils';
 import { AsyncQueue } from './queue';
 import { Message, newRequest, Response } from './message';
 import { WebRPayload, WebRPayloadWorker, webRPayloadAsError } from '../payload';
+import { WebRChannelError } from '../error';
 
 // The channel structure is asymmetric:
 //
@@ -34,6 +35,7 @@ export abstract class ChannelMain {
   systemQueue = new AsyncQueue<Message>();
 
   #parked = new Map<string, { resolve: ResolveFn; reject: RejectFn }>();
+  #closed = false;
 
   abstract initialised: Promise<unknown>;
   abstract close(): void;
@@ -56,6 +58,9 @@ export abstract class ChannelMain {
   }
 
   write(msg: Message): void {
+    if (this.#closed) {
+      throw new WebRChannelError("The webR communication channel has been closed.");
+    }
     this.inputQueue.put(msg);
   }
 
@@ -70,6 +75,7 @@ export abstract class ChannelMain {
   }
 
   protected putClosedMessage(): void {
+    this.#closed = true;
     this.outputQueue.put({ type: 'closed' });
   }
 

--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -310,6 +310,9 @@ export class WebR {
         case 'console.error':
           console.error(msg.data);
           break;
+        case 'close':
+          this.#chan.close();
+          break;
         default:
           throw new WebRError('Unknown system message type `' + msg.type + '`');
       }


### PR DESCRIPTION
This PR makes two changes:

1) If `WebAssembly.RuntimeError` is raised and bubbles all the way up to the top level, catch it and report the problem as unrecoverable on `console.error()`. Then close the communication channel, terminating the worker thread.

2) If a communication channel has been closed, reject any promises trying to write on the channel with a `WebRChannelError`.

Closes #464, because the OOM error is a `WebAssembly.RuntimeError`.