### PR TITLE
add dark mode option to Quarto site

### DIFF
--- a/src/docs/_quarto.yml
+++ b/src/docs/_quarto.yml
@@ -50,7 +50,9 @@ website:
 
 format:
   html:
-    theme: cosmo
+    theme: 
+      light: cosmo
+      dark: darkly
     link-external-newwindow: true
     link-external-filter: '^(?:http:|https:)\/\/docs\.r-wasm\.org'
     toc: true


### PR DESCRIPTION
added dark theme to yml to enable toggle between cosmo and darkly
fonts will be inconsistent but @georgestagg is OK with this (dev day pers. comm.)