### PR TITLE
Add workaround for old freetype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,9 @@ RUN rm -rf /tmp/rig
 RUN rm -rf libs/download libs/build src/node_modules R/download
 RUN cd src && make clean
 
+# Temp workaround for https://github.com/emscripten-core/emscripten/issues/22571
+RUN sed -i.bak 's|#define TYPEOF|#define FT_TYPEOF|g' /opt/emsdk/upstream/emscripten/cache/sysroot/include/freetype2/config/ftconfig.h
+
 # Step 3: Squash docker image layers
 FROM webr
 COPY --from=scratch / /


### PR DESCRIPTION
Workaround for the TYPEOF macro conflict in old freetype versions. This will enable to build the `systemfonts` R package again, until we have upgraded the emscripten stack.

Fixes #480
