### PR TITLE
Added libaec

### DIFF
--- a/libs/recipes/libaec/rules.mk
+++ b/libs/recipes/libaec/rules.mk
@@ -1,0 +1,22 @@
+#  https://gitlab.dkrz.de/k202009/libaec/-/blob/master/INSTALL.md?ref_type=heads
+LIBAEC_VERSION = 1.1.3
+LIBAEC_TARBALL = $(DOWNLOAD)/libaec-$(LIBAEC_VERSION).tar.gz
+LIBAEC_URL = https://gitlab.dkrz.de/k202009/libaec/-/archive/v$(LIBAEC_VERSION)/libaec-v$(LIBAEC_VERSION).tar.gz
+
+
+.PHONY: libaec
+libaec: $(LIBAEC_WASM_LIB)
+
+$(LIBAEC_TARBALL):
+	mkdir -p $(DOWNLOAD)
+	wget $(LIBAEC_URL) -O $@
+
+$(LIBAEC_WASM_LIB): $(LIBAEC_TARBALL)
+	mkdir -p $(BUILD)/libaec-$(LIBAEC_VERSION)/build
+	tar -C $(BUILD)/libaec-$(LIBAEC_VERSION) -xf $(LIBAEC_TARBALL)
+	cd $(BUILD)/libaec-$(LIBAEC_VERSION)/build && \
+	emconfigure ../configure \
+	  --enable-shared=no \
+	  --enable-static=yes \
+	  --prefix=$(WASM) && \
+	emmake make install

--- a/libs/recipes/libaec/rules.mk
+++ b/libs/recipes/libaec/rules.mk
@@ -1,8 +1,7 @@
 #  https://gitlab.dkrz.de/k202009/libaec/-/blob/master/INSTALL.md?ref_type=heads
 LIBAEC_VERSION = 1.1.3
 LIBAEC_TARBALL = $(DOWNLOAD)/libaec-$(LIBAEC_VERSION).tar.gz
-LIBAEC_URL = https://gitlab.dkrz.de/k202009/libaec/-/archive/v$(LIBAEC_VERSION)/libaec-v$(LIBAEC_VERSION).tar.gz
-
+LIBAEC_URL = https://gitlab.dkrz.de/-/project/117/uploads/dc5fc087b645866c14fa22320d91fb27/libaec-1.1.3.tar.gz
 
 .PHONY: libaec
 libaec: $(LIBAEC_WASM_LIB)
@@ -15,7 +14,7 @@ $(LIBAEC_WASM_LIB): $(LIBAEC_TARBALL)
 	mkdir -p $(BUILD)/libaec-$(LIBAEC_VERSION)/build
 	tar -C $(BUILD)/libaec-$(LIBAEC_VERSION) -xf $(LIBAEC_TARBALL)
 	cd $(BUILD)/libaec-$(LIBAEC_VERSION)/build && \
-	emconfigure ../configure \
+	emconfigure ../libaec-$(LIBAEC_VERSION)/configure \
 	  --enable-shared=no \
 	  --enable-static=yes \
 	  --prefix=$(WASM) && \

--- a/libs/recipes/libaec/targets.mk
+++ b/libs/recipes/libaec/targets.mk
@@ -1,0 +1,10 @@
+# https://github.com/Homebrew/homebrew-core/blob/cd71c6db511f368436d9b0bec570f282a4eb3d05/Formula/lib/libaec.rb#L23C3-L28C34
+# link_overwrite "include/szlib.h"  (WASM_CPPFLAGS += -I$(WASM)/include) should be able to find?
+# link_overwrite "lib/libsz.a"      (WASM_LDFLAGS += -L$(WASM)/lib) should be able to find?
+# link_overwrite "lib/libsz.dylib"
+# link_overwrite "lib/libsz.2.dylib"
+# link_overwrite "lib/libsz.so"
+# link_overwrite "lib/libsz.so.2"
+
+LIBAEC_WASM_LIB = $(WASM)/lib/libsz.a
+OPTIONAL_WASM_LIBS += $(LIBAEC_WASM_LIB)


### PR DESCRIPTION
Added support: `SZIP` or `libaec`. Goal is to compile packages that might require `-lsz` flag.