### PR TITLE
Do not call strip in Makevars

### DIFF
--- a/packages/webr-vars.mk
+++ b/packages/webr-vars.mk
@@ -42,3 +42,6 @@ override LIBINTL =
 
 override LIBR =
 override ALL_LIBS = $(PKG_LIBS) $(SHLIB_LIBADD) $(LIBR) $(LIBINTL)
+
+override STRIP_STATIC_LIB = touch
+override STRIP_SHARED_LIB = touch


### PR DESCRIPTION
Some packages use `$(STRIP_STATIC_LIB)` or `$(STRIP_SHARED_LIB)` on vendored libraries. However calling native `/usr/bin/strip` on a WebAssembly binary gives an error. So we make this a no-op.