### PR TITLE
Update utils.ts - fix for Firefox

### DIFF
--- a/src/webR/utils.ts
+++ b/src/webR/utils.ts
@@ -111,7 +111,7 @@ export function newCrossOriginWorker(url: string, cb: (worker: Worker) => void, 
 export function isCrossOrigin(urlString: string) {
   if (IN_NODE) return false;
   const url1 = new URL(location.href);
-  const url2 = new URL(urlString, location.origin);
+  const url2 = new URL(urlString);
   if (url1.host === url2.host && url1.port === url2.port && url1.protocol === url2.protocol) {
     return false;
   }


### PR DESCRIPTION
in Firefox, if page is loaded using "file://" protocol, location.origin is "null", which causes an error: "URL constructor: null is not a valid URL."