### PR TITLE
Fix WebSocket proxy on NodeJS

### DIFF
--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -14,7 +14,7 @@ if (process.argv.some((x) => x === '--prod')) {
 }
 
 // Node modules are imported only conditionally in browser -- stub them out during bundling
-const builtins = ['worker_threads', 'path', 'fs', 'ws', 'url', 'child_process', 'http', 'https', 'crypto'];
+const builtins = ['worker_threads', 'path', 'fs', 'ws', 'url', 'child_process', 'http', 'https', 'crypto', 'module'];
 const builtinList = builtins.reduce((prev, val, index) => (index > 0 ? `${prev}|${val}` : val));
 const builtinRegexp = new RegExp(`^(${builtinList})\\/?(.+)?`);
 const blankImportPlugin = {

--- a/src/tests/webR/webr-worker.test.ts
+++ b/src/tests/webR/webr-worker.test.ts
@@ -98,6 +98,23 @@ describe('Download files', () => {
   });
 });
 
+//This is the SOCKS5 hello greeting. This is needed for curl
+describe('Emulated POSIX TCP Sockets over WebSockets', () => {
+  test('Connect SOCKS5 server via implicit WebSocket', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => null);
+    const pkg = (await webR.evalR(`
+      con <- socketConnection("ws.r-universe.dev",443,open = "r+b",blocking = TRUE)
+      Sys.sleep(2)
+      writeBin(as.raw(c(05,01,00)), con)
+      Sys.sleep(2)
+      response <- readBin(con, what = "raw", n = 2)
+      close(con)
+      identical(response, as.raw(c(05, 255)))
+    `)) as RLogical;
+    expect(await pkg.toBoolean()).toEqual(true);
+    warnSpy.mockRestore();
+  });
+});
 
 describe('Test webR virtual filesystem', () => {
   const testFileContents = new Uint8Array([1, 2, 4, 7, 11, 16, 22, 29, 37, 46]);

--- a/src/webR/chan/proxy-websocket.ts
+++ b/src/webR/chan/proxy-websocket.ts
@@ -16,7 +16,15 @@ export class WebSocketMap {
   #map = new Map<string, WebSocket>();
 
   constructor(readonly chan: ChannelMain) {
-    this.WebSocket = IN_NODE ? require('ws') as typeof WebSocket : WebSocket;
+    if (IN_NODE) {
+      // Use the built-in WebSocket if available (Node.js >= 21), otherwise
+      // fall back to the 'ws' npm package which must be installed separately.
+      this.WebSocket = ('WebSocket' in globalThis)
+        ? globalThis.WebSocket
+        : require('ws') as typeof WebSocket;
+    } else {
+      this.WebSocket = WebSocket;
+    }
   }
 
   new(uuid: string, url: string | URL, protocols?: string | string[]) {
@@ -136,6 +144,23 @@ export class WebSocketProxyFactory {
         const ev = new Event("error");
         this.dispatchEvent(ev);
         this.onerror?.(ev);
+      }
+
+      // Node.js EventEmitter-style .on() for Emscripten SOCKFS compatibility.
+      // In Node.js, SOCKFS registers socket events via .on() rather than
+      // .onopen/.onmessage etc., so we must support both APIs.
+      on(event: string, handler: (...args: unknown[]) => void): this {
+        if (event === 'message') {
+          // SOCKFS expects handler(data, isBinary) like the 'ws' npm package
+          this.addEventListener('message', (ev: Event) => {
+            const data = (ev as MessageEvent<unknown>).data;
+            const isBinary = !(typeof data === 'string');
+            handler(data, isBinary);
+          });
+        } else {
+          this.addEventListener(event, () => handler());
+        }
+        return this;
       }
     };
   }

--- a/src/webR/emscripten.ts
+++ b/src/webR/emscripten.ts
@@ -22,6 +22,11 @@ export interface Module extends EmscriptenModule {
   }
   createLazyFilesystem: () => void;
   monitorRunDependencies: (n: number) => void;
+  websocket?: {
+    url?: string;
+    WebSocket?: typeof WebSocket;
+    subprotocol?: string;
+  };
   noImageDecoding: boolean;
   noAudioDecoding: boolean;
   noWasmDecoding: boolean;

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -1041,7 +1041,19 @@ function init(config: Required<WebROptions>) {
   // Proxy web APIs to main thread.
   // Requires channel SyncRequest support for handling events.
   if (chan?.WebSocketProxy) {
-    globalThis.WebSocket = chan.WebSocketProxy;
+    const wsProxy = chan.WebSocketProxy;
+    globalThis.WebSocket = wsProxy;
+    // In Node.js, Emscripten's SOCKFS always uses require('ws') regardless of
+    // globalThis.WebSocket. Intercept require('ws') at the Node.js module
+    // level so SOCKFS receives our proxy class instead.
+    if (IN_NODE) {
+      const nodeModule = require('module') as { _load: (...args: unknown[]) => unknown };
+      const origLoad = nodeModule._load.bind(nodeModule);
+      nodeModule._load = (id: unknown, ...rest: unknown[]) => {
+        if (id === 'ws') return wsProxy;
+        return origLoad(id, ...rest);
+      };
+    }
   }
   if (chan?.WorkerProxy) {
     globalThis.Worker = chan.WorkerProxy;


### PR DESCRIPTION
Currently even simply trying to connect to the websocket seems to work in the browser but error instantly in node.

```r
con <- socketConnection("ws.r-universe.dev", 443, open = "r+b", blocking = TRUE)
```


Claude came up with the hypothesis that the problem is that [emscripten hardcodes require('ws')](https://github.com/emscripten-core/emscripten/blob/6ea9c28c38cdd40c1032fa04400c9d16230ee180/src/lib/libsockfs.js#L219) and thereby ignores our `globalThis.WebSocket` proxy.

So this is a workaround. In addition it now uses the new [Native WebSocket Client in Node.js](https://nodejs.org/learn/getting-started/websocket#native-websocket-client-in-nodejs) when available.


Fixes #581