### PR TITLE
Required updates for Ubuntu 26.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN /opt/R/current/bin/R -q -e 'install.packages("pak", lib = .Library)'
 RUN /opt/R/current/bin/R -q -e 'pak::pak("r-wasm/rwasm", lib = .Library)'
 # Temporary workaround for https://github.com/r-lib/pkgdepends/issues/462
 # TODO: Remove this once a fixed version of pkgdepends has released
-RUN /opt/R/current/bin/R -q -e 'pak::pak("r-lib/pkgdepends@v0.9.0", lib = .Library)'
+RUN /opt/R/current/bin/R -q -e 'pak::pak("r-lib/pkgdepends@v0.9.0-patched", lib = .Library)'
 
 # Setup P3M
 RUN echo 'options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/resolute/latest"))' >> /root/.Rprofile

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN /opt/R/current/bin/R -q -e 'pak::pak("r-wasm/rwasm", lib = .Library)'
 RUN /opt/R/current/bin/R -q -e 'pak::pak("r-lib/pkgdepends@v0.9.0", lib = .Library)'
 
 # Setup P3M
-RUN echo 'options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/noble/latest"))' >> /root/.Rprofile
+RUN echo 'options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/resolute/latest"))' >> /root/.Rprofile
 
 # Download webR and configure for LLVM flang
 ARG WEBRCI_REPO="https://github.com/r-wasm/webr.git"

--- a/src/tests/module/web-esbuild-ts/package-lock.json
+++ b/src/tests/module/web-esbuild-ts/package-lock.json
@@ -12,13 +12,13 @@
       },
       "devDependencies": {
         "esbuild": "^0.25.9",
-        "playwright": "^1.40.0",
+        "playwright": "^1.61.0",
         "typescript": "^5.0.2"
       }
     },
     "../../..": {
       "name": "webr",
-      "version": "0.5.8-dev",
+      "version": "0.6.1-dev",
       "license": "SEE LICENSE IN LICENCE.md",
       "dependencies": {
         "@codemirror/autocomplete": "^6.8.1",
@@ -576,13 +576,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -595,9 +595,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/tests/module/web-esbuild-ts/package.json
+++ b/src/tests/module/web-esbuild-ts/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "esbuild": "^0.25.9",
     "typescript": "^5.0.2",
-    "playwright": "^1.40.0"
+    "playwright": "^1.61.0"
   }
 }

--- a/src/tests/module/web-script-mjs/package-lock.json
+++ b/src/tests/module/web-script-mjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "webr-web-script-mjs-test",
       "version": "0.0.1",
       "devDependencies": {
-        "playwright": "^1.40.0"
+        "playwright": "^1.61.0"
       }
     },
     "node_modules/fsevents": {
@@ -27,13 +27,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/tests/module/web-script-mjs/package.json
+++ b/src/tests/module/web-script-mjs/package.json
@@ -6,6 +6,6 @@
     "test": "node test-server.js"
   },
   "devDependencies": {
-    "playwright": "^1.40.0"
+    "playwright": "^1.61.0"
   }
 }

--- a/src/tests/module/web-vite-ts/package-lock.json
+++ b/src/tests/module/web-vite-ts/package-lock.json
@@ -11,7 +11,7 @@
         "webr": "file:../../.."
       },
       "devDependencies": {
-        "playwright": "^1.40.0",
+        "playwright": "^1.61.0",
         "typescript": "^5.0.2",
         "vite": "^6.4.1",
         "vite-tsconfig-paths": "^5.1.4"
@@ -19,7 +19,7 @@
     },
     "../../..": {
       "name": "webr",
-      "version": "0.5.8-dev",
+      "version": "0.6.1-dev",
       "license": "SEE LICENSE IN LICENCE.md",
       "dependencies": {
         "@codemirror/autocomplete": "^6.8.1",
@@ -981,13 +981,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/tests/module/web-vite-ts/package.json
+++ b/src/tests/module/web-vite-ts/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.0.2",
     "vite": "^6.4.1",
     "vite-tsconfig-paths": "^5.1.4",
-    "playwright": "^1.40.0"
+    "playwright": "^1.61.0"
   }
 }

--- a/src/tests/module/web-webpack-ts/package-lock.json
+++ b/src/tests/module/web-webpack-ts/package-lock.json
@@ -11,7 +11,7 @@
         "webr": "file:../../.."
       },
       "devDependencies": {
-        "playwright": "^1.40.0",
+        "playwright": "^1.61.0",
         "ts-loader": "^9.5.1",
         "typescript": "^5.0.2",
         "webpack": "^5.89.0",
@@ -20,7 +20,7 @@
     },
     "../../..": {
       "name": "webr",
-      "version": "0.5.8-dev",
+      "version": "0.6.1-dev",
       "license": "SEE LICENSE IN LICENCE.md",
       "dependencies": {
         "@codemirror/autocomplete": "^6.8.1",
@@ -1239,13 +1239,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/tests/module/web-webpack-ts/package.json
+++ b/src/tests/module/web-webpack-ts/package.json
@@ -14,6 +14,6 @@
     "webpack-cli": "^5.1.4",
     "ts-loader": "^9.5.1",
     "typescript": "^5.0.2",
-    "playwright": "^1.40.0"
+    "playwright": "^1.61.0"
   }
 }


### PR DESCRIPTION
Because the upstream image has bumped, we need to fix some things here as well:

 1. Update apt repo `noble` -> `resolute`
 2. Update npm package `playwright` to a version that supports ubuntu26
 3. Move tag for `pkgdepends@0.9.0` to include API changes for R-4.6.