### PR TITLE
Add optional downloadTimeout to bound package/file downloads

### DIFF
--- a/src/webR/webr-main.ts
+++ b/src/webR/webr-main.ts
@@ -178,6 +178,13 @@ export interface WebROptions {
   serviceWorkerUrl?: string;
 
   /**
+   * Timeout in milliseconds for each package/file download request. Prevents an
+   * unreachable repo from hanging the worker thread. `0` disables the timeout.
+   * Default: `0`.
+   */
+  downloadTimeout?: number;
+
+  /**
    * The WebAssembly user's home directory and initial working directory.
    * Default: `'/home/web_user'`
    */
@@ -218,6 +225,7 @@ const defaultOptions = {
   baseUrl: BASE_URL,
   serviceWorkerUrl: '',
   repoUrl: PKG_BASE_URL,
+  downloadTimeout: 0,
   homedir: '/home/web_user',
   interactive: true,
   channelType: ChannelType.Automatic,

--- a/src/webR/webr-worker.ts
+++ b/src/webR/webr-worker.ts
@@ -600,6 +600,7 @@ function downloadFileContent(url: string, headers: Array<string> = [], maxRedire
   const request = new XMLHttpRequest();
   request.open('GET', url, false);
   request.responseType = 'arraybuffer';
+  request.timeout = _config.downloadTimeout;
 
   try {
     headers.forEach((header) => {


### PR DESCRIPTION
downloadFileContent issues a synchronous XMLHttpRequest with no timeout, so a repository that's unreachable in a way that leaves the connection pending (accepted-but-no-response, or a black-holed route) parks the worker thread inside send() indefinitely — R can't service interrupts while blocked there, so webr::install() never returns and the session wedges. R's options(timeout=) doesn't reach this path. This adds an optional downloadTimeout (ms) so consumers can bound these requests; on expiry the existing catch turns it into a clean download failure and the installer can fall through to the next repo. Default 0 preserves current behavior (no timeout) — fully non-breaking. timeout on a sync XHR is permitted in a Worker/Node context (only disallowed when the global is a Window). Could be related to #235.